### PR TITLE
implement Resource level tags (#75)

### DIFF
--- a/GeoHealthCheck/app.py
+++ b/GeoHealthCheck/app.py
@@ -42,7 +42,7 @@ from __init__ import __version__
 from healthcheck import run_test_resource
 from init import DB
 from enums import RESOURCE_TYPES
-from models import Resource, Run, User
+from models import Resource, Run, Tag, User
 from util import render_template2, send_email
 import views
 
@@ -175,13 +175,15 @@ def context_processors():
     """global context processors for templates"""
 
     rtc = views.get_resource_types_counts()
+    tags = views.get_tag_counts()
     return {
         'app_version': __version__,
         'next_page_refresh': next_page_refresh(),
         'resource_types': RESOURCE_TYPES,
         'resource_types_counts': rtc['counts'],
         'resources_total': rtc['total'],
-        'languages': LANGUAGES
+        'languages': LANGUAGES,
+        'tags': tags
     }
 
 
@@ -190,13 +192,16 @@ def home():
     """homepage"""
 
     resource_type = None
+    tag = None
 
     if request.args.get('resource_type') in RESOURCE_TYPES.keys():
         resource_type = request.args['resource_type']
 
+    tag = request.args.get('tag')
+
     query = request.args.get('q')
 
-    response = views.list_resources(resource_type, query)
+    response = views.list_resources(resource_type, query, tag)
     return render_template('home.html', response=response)
 
 
@@ -433,7 +438,10 @@ def add():
     if request.method == 'GET':
         return render_template('add.html')
 
+    tag_list = []
+
     resource_type = request.form['resource_type']
+    tags = request.form['tags']
     url = request.form['url'].strip()
     resource = Resource.query.filter_by(resource_type=resource_type,
                                         url=url).first()
@@ -454,7 +462,12 @@ def add():
         return redirect(url_for('add', lang=g.current_lang,
                                 resource_type=resource_type))
 
-    resource_to_add = Resource(current_user, resource_type, title, url)
+    if tags is not None:
+        for tag in tags.split(','):
+            tag_list.append(Tag(name=tag))
+
+    resource_to_add = Resource(current_user, resource_type, title, url,
+                               tags=tag_list)
     run_to_add = Run(resource_to_add, success, response_time, message,
                      start_time)
 

--- a/GeoHealthCheck/templates/add.html
+++ b/GeoHealthCheck/templates/add.html
@@ -21,6 +21,9 @@
         <input type="text" name="url" class="form-control" placeholder="url" required>
         <p class="help-block">{{ _('Enter the URL without any query parameters') }}:<br/>{{ _('good') }}: <code>http://host/wms</code><br/>{{ _('bad') }}:<code>http://host/wms?service=WMS&version=1.1.1&request=GetCapabilities</code></p>
     </div>
+    <div class="form-group input-group col-sm-5">
+        <input type="text" name="tags" class="form-control" data-role="tagsinput" placeholder="{{ _('Enter tags') }}">
+    </div>
     <div class="form-group">
         <button type="submit" class="btn btn-success">{{ _('Submit') }}</button>
     </div>

--- a/GeoHealthCheck/templates/layout.html
+++ b/GeoHealthCheck/templates/layout.html
@@ -8,6 +8,7 @@
         <link rel="icon" href="../../favicon.ico">
         <title>{{ config['GHC_SITE_TITLE'] }}</title>
         <link href="{{ url_for('static', filename='lib/vendor/bootstrap/css/bootstrap.min.css') }}" rel="stylesheet" type="text/css">
+        <link href="{{ url_for('static', filename='lib/bootstrap-tagsinput/dist/bootstrap-tagsinput.css') }}" rel="stylesheet" type="text/css">
         <link href="{{ url_for('static', filename='lib/dist/css/sb-admin-2.css') }}" rel="stylesheet" type="text/css">
         <link href="{{ url_for('static', filename='lib/vendor/font-awesome/css/font-awesome.min.css') }}" rel="stylesheet" type="text/css">
         <link href="{{ url_for('static', filename='lib/vendor/datatables-plugins/dataTables.bootstrap.min.js') }}" rel="stylesheet">
@@ -88,6 +89,21 @@
                     </ul>
                     <ul class="nav nav-sidebar">
                         <li>
+                            <i class="fa fa-filter fa-fw"></i><span>{{ _('Tags') }}</span>
+                            <ul class="nav nav-second-level">
+                                {% for tag, count in tags.items() %}
+                                {% if request.args.get('tag') == tag %}
+                                <li><a class="active" href="{{ url_for('home', lang=g.current_lang, tag=tag) }}">{{ tag }} ({{ count }})</a></li>
+                                {% else %}
+                                <li><a href="{{ url_for('home', lang=g.current_lang, tag=tag) }}">{{ tag }} ({{ count }})</a></li>
+                                {% endif %}
+                                {% endfor %}
+                                <li><i><a href="{{ url_for('home', lang=g.current_lang) }}">{{ _('Show All') }}</a></i></li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <ul class="nav nav-sidebar">
+                        <li>
                             <i class="fa fa-cog fa-fw"></i>{{ _('Settings') }}
                             <ul class="nav nav-second-level">
                                 <li><a>{{ _('History') }}: {{ config['GHC_RETENTION_DAYS'] }} {{ _('days') }}</a></li>
@@ -113,6 +129,7 @@
         <footer><div class="footer text-center">{{ _('Powered by') }} <a href="http://geohealthcheck.org">GeoHealthCheck</a> {{ app_version }}</div></footer>
         <script src="{{ url_for('static', filename='lib/vendor/jquery/jquery.min.js') }}"></script>
         <script src="{{ url_for('static', filename='lib/vendor/bootstrap/js/bootstrap.min.js') }}"></script>
+        <script src="{{ url_for('static', filename='lib/bootstrap-tagsinput/dist/bootstrap-tagsinput.min.js') }}"></script>
         <script src="{{ url_for('static', filename='lib/vendor/raphael/raphael.min.js') }}"></script>
         <script src="{{ url_for('static', filename='lib/vendor/morrisjs/morris.min.js') }}"></script>
         <script src="{{ url_for('static', filename='lib/vendor/datatables/js/jquery.dataTables.min.js') }}"></script>

--- a/GeoHealthCheck/templates/resource.html
+++ b/GeoHealthCheck/templates/resource.html
@@ -40,6 +40,10 @@
                 <td><a href="{{ resource.get_capabilities_url }}">{{ resource.url }}</a></td>
             </tr>
             <tr>
+                <th>Tags</th>
+                <td><input type="text" value="{{ resource.tags2csv }}" data-role="tagsinput" disabled/></td>
+            </tr>
+            <tr>
                 <th>{{ _('Response Times (seconds)') }}</th>
                 <td>
                     <ul>

--- a/GeoHealthCheck/translations/de/LC_MESSAGES/messages.po
+++ b/GeoHealthCheck/translations/de/LC_MESSAGES/messages.po
@@ -340,3 +340,8 @@ msgstr "Reaktionszeit"
 msgid "Show All"
 msgstr ""
 
+msgid "Tags"
+msgstr ""
+
+msgid "Enter tags"
+msgstr ""

--- a/GeoHealthCheck/translations/de_DE/LC_MESSAGES/messages.po
+++ b/GeoHealthCheck/translations/de_DE/LC_MESSAGES/messages.po
@@ -340,3 +340,8 @@ msgstr "Reaktionszeit"
 msgid "Show All"
 msgstr ""
 
+msgid "Tags"
+msgstr ""
+
+msgid "Enter tags"
+msgstr ""

--- a/GeoHealthCheck/translations/en/LC_MESSAGES/messages.po
+++ b/GeoHealthCheck/translations/en/LC_MESSAGES/messages.po
@@ -333,3 +333,9 @@ msgstr ""
 #: GeoHealthCheck/templates/layout.html:85
 msgid "Show All"
 msgstr ""
+
+msgid "Tags"
+msgstr ""
+
+msgid "Enter tags"
+msgstr ""

--- a/GeoHealthCheck/translations/es_BO/LC_MESSAGES/messages.po
+++ b/GeoHealthCheck/translations/es_BO/LC_MESSAGES/messages.po
@@ -365,3 +365,9 @@ msgstr "Tiempo de respuesta"
 #: GeoHealthCheck/templates/layout.html:85
 msgid "Show All"
 msgstr "Mostrar todo"
+
+msgid "Tags"
+msgstr ""
+
+msgid "Enter tags"
+msgstr ""

--- a/GeoHealthCheck/translations/fr/LC_MESSAGES/messages.po
+++ b/GeoHealthCheck/translations/fr/LC_MESSAGES/messages.po
@@ -339,3 +339,8 @@ msgstr "Temps de réponse"
 msgid "Show All"
 msgstr "Montrer tout"
 
+msgid "Tags"
+msgstr ""
+
+msgid "Enter tags"
+msgstr ""

--- a/GeoHealthCheck/translations/nl_NL/LC_MESSAGES/messages.po
+++ b/GeoHealthCheck/translations/nl_NL/LC_MESSAGES/messages.po
@@ -337,3 +337,9 @@ msgstr "Response Tijd"
 #: GeoHealthCheck/templates/layout.html:85
 msgid "Show All"
 msgstr "Allen Tonen"
+
+msgid "Tags"
+msgstr ""
+
+msgid "Enter tags"
+msgstr ""

--- a/GeoHealthCheck/views.py
+++ b/GeoHealthCheck/views.py
@@ -31,7 +31,7 @@ import models
 import util
 
 
-def list_resources(resource_type=None, query=None):
+def list_resources(resource_type=None, query=None, tag=None):
     """return all resources"""
 
     reliability_values = []
@@ -61,6 +61,10 @@ def list_resources(resource_type=None, query=None):
         field, term = get_query_field_term(query)
         response['resources'] = models.Resource.query.filter(
             field.ilike(term)).all()
+
+    if tag is not None:
+        response['resources'] = models.Resource.query.filter(
+            models.Tag.name.in_([tag])).all()
 
     if 'resources' not in response:
         # No query nor resource_type provided: fetch all resources
@@ -103,6 +107,18 @@ def get_resource_types_counts():
         'counts': mrt[0],
         'total': mrt[1]
     }
+
+
+def get_tag_counts():
+    """return all tag counts"""
+
+    return models.get_tag_counts()
+
+
+def get_all_tags():
+    """return all tags"""
+
+    return models.get_tag_counts()
 
 
 def get_query_field_term(query):

--- a/pavement.py
+++ b/pavement.py
@@ -27,6 +27,7 @@
 #
 # =================================================================
 
+import glob
 import os
 import shutil
 import tempfile
@@ -109,6 +110,15 @@ def setup():
         content = urlopen('http://ejohn.org/files/jspark.js').read()
         content.replace('red', 'green')
         f.write(content)
+
+    # install bootstrap-tagsinput to static/lib
+    bs_tags = 'https://github.com/bootstrap-tagsinput/bootstrap-tagsinput/archive/0.8.0.zip'  # noqa
+
+    zipstr = StringIO(urlopen(bs_tags).read())
+    zipfile_obj = zipfile.ZipFile(zipstr)
+    zipfile_obj.extractall(options.base.static_lib)
+    dirname = glob.glob(options.base.static_lib / 'bootstrap-tagsinput*')[0]
+    os.rename(dirname, ''.join(dirname.rsplit('-', 1)[:-1]))
 
     # install leafletjs to static/lib
     leafletjs = 'http://cdn.leafletjs.com/downloads/leaflet-0.7.5.zip'


### PR DESCRIPTION
This PR implements Resource level tags per #75.  Notes:

- `Resource.tags` is a foreign key to a `Tags` model
- the UI uses bootstrap-tagsinput when adding a resource
- 'Tags' added to the main layout filters (in addition to Resource Types)