### PR TITLE
fix / update notification email functionality

### DIFF
--- a/GeoHealthCheck/app.py
+++ b/GeoHealthCheck/app.py
@@ -463,8 +463,8 @@ def add():
                                 resource_type=resource_type))
 
     if tags:
-        tag_found = False
         for tag in tags:
+            tag_found = False
             for tag_obj in Tag.query.all():
                 if tag == tag_obj.name:  # use existing
                     tag_found = True

--- a/GeoHealthCheck/config_main.py
+++ b/GeoHealthCheck/config_main.py
@@ -43,7 +43,7 @@ GHC_NOTIFICATIONS = False
 GHC_NOTIFICATIONS_VERBOSITY = True
 GHC_WWW_LINK_EXCEPTION_CHECK = False
 GHC_ADMIN_EMAIL = 'you@example.com'
-GHC_NOTIFICATIONS_EMAIL = 'you2@example.com'
+GHC_NOTIFICATIONS_EMAIL = ['you2@example.com']
 GHC_SITE_TITLE = 'GeoHealthCheck Demonstration'
 GHC_SITE_URL = 'http://host'
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -130,7 +130,7 @@ You can override these settings in ``instance/config_site.py``:
 - **GHC_NOTIFICATIONS_VERBOSITY**: receive additional email notifications than just ``Failing`` and ``Fixed`` (default ``True``)
 - **GHC_WWW_LINK_EXCEPTION_CHECK**: turn on checking for OGC Exceptions in ``WWW:LINK`` Resource responses (default ``False``)
 - **GHC_ADMIN_EMAIL**: email address of administrator / contact- notification emails will come from this address
-- **GHC_NOTIFICATIONS_EMAIL**: email address that notifications should come to. Use a different address to **GHC_ADMIN_EMAIL** if you have trouble receiving notification emails
+- **GHC_NOTIFICATIONS_EMAIL**: list of email addresses that notifications should come to. Use a different address to **GHC_ADMIN_EMAIL** if you have trouble receiving notification emails
 - **GHC_SITE_TITLE**: title used for installation / deployment
 - **GHC_SITE_URL**: url of the installation / deployment
 - **GHC_SMTP**:  configure SMTP settings if **GHC_NOTIFICATIONS** is enabled


### PR DESCRIPTION
cc @archaeogeek @justb4 
This PR makes more robust the notification email handling and makes `GHC_NOTIFICATIONS_EMAIL` a list instead of a string to support sending to multiple email addresses.