### PR TITLE
#95 prevent Null coordinates inserted in DB, make 0,0

### DIFF
--- a/GeoHealthCheck/models.py
+++ b/GeoHealthCheck/models.py
@@ -216,7 +216,9 @@ class Resource(DB.Model):
         try:
             self.latitude, self.longitude = util.geocode(url)
         except Exception as err:  # skip storage
-            LOGGER.exception('Could not derive coordinates: %s', err)
+            LOGGER.exception('Could not derive coordinates, set to zero-island: %s', err)
+            self.latitude = 0.0
+            self.longitude = 0.0
 
     def __repr__(self):
         return '<Resource %r %r>' % (self.identifier, self.title)

--- a/GeoHealthCheck/models.py
+++ b/GeoHealthCheck/models.py
@@ -216,7 +216,7 @@ class Resource(DB.Model):
         try:
             self.latitude, self.longitude = util.geocode(url)
         except Exception as err:  # skip storage
-            LOGGER.exception('Could not derive coordinates, set to zero-island: %s', err)
+            LOGGER.exception('Could not derive coordinates: %s', err)
             self.latitude = 0.0
             self.longitude = 0.0
 


### PR DESCRIPTION
Fixed by setting to 0,0 (zero-island) when geocoding fails for some reason.