### PR TITLE
replace WOUDC WMS by PDOK BAG WMS in testdata

### DIFF
--- a/tests/data/fixtures.json
+++ b/tests/data/fixtures.json
@@ -13,13 +13,14 @@
     "pdok": "pdok"
   },
   "resources": {
-    "WOUDC WMS": {
+    "PDOK BAG WMS": {
       "owner": "admin",
       "resource_type": "OGC:WMS",
-      "title": "WOUDC Web Map Service",
-      "url": "http://geo.woudc.org/ows",
+      "title": "PDOK BAG Web Map Service",
+      "url": "http://geodata.nationaalgeoregister.nl/bag/wms",
       "tags": [
-        "ows"
+        "ows",
+        "pdok"
       ]
     },
     "WOUDC WFS": {
@@ -79,16 +80,16 @@
     }
   },
   "probe_vars": {
-    "WOUDC WMS - GetCaps": {
-      "resource": "WOUDC WMS",
+    "PDOK BAG WMS - GetCaps": {
+      "resource": "PDOK BAG WMS",
       "probe_class": "GeoHealthCheck.plugins.probe.owsgetcaps.WmsGetCaps",
       "parameters": {
         "service": "WMS",
         "version": "1.0.0"
       }
     },
-    "WOUDC WMS - Drilldown": {
-      "resource": "WOUDC WMS",
+    "PDOK BAG WMS - Drilldown": {
+      "resource": "PDOK BAG WMS",
       "probe_class": "GeoHealthCheck.plugins.probe.wmsdrilldown.WmsDrilldown",
       "parameters": {
         "drilldown_level": "minor"
@@ -158,8 +159,8 @@
     }
   },
   "check_vars": {
-    "WOUDC WMS - GetCaps - XML Parse": {
-      "probe_vars": "WOUDC WMS - GetCaps",
+    "PDOK BAG WMS - GetCaps - XML Parse": {
+      "probe_vars": "PDOK BAG WMS - GetCaps",
       "check_class": "GeoHealthCheck.plugins.check.checks.XmlParse",
       "parameters": {}
     },

--- a/tests/data/minimal.json
+++ b/tests/data/minimal.json
@@ -10,17 +10,17 @@
   "tags": {
   },
   "resources": {
-    "WOUDC WMS": {
+    "PDOK BAG WMS": {
       "owner": "admin",
       "resource_type": "OGC:WMS",
-      "title": "WOUDC Web Map Service",
-      "url": "http://geo.woudc.org/ows",
+      "title": "PDOK BAG Web Map Service",
+      "url": "http://geodata.nationaalgeoregister.nl/bag/wms",
       "tags": []
     }
   },
   "probe_vars": {
-    "WOUDC WMS - GetCaps": {
-      "resource": "WOUDC WMS",
+    "PDOK BAG WMS - GetCaps": {
+      "resource": "PDOK BAG WMS",
       "probe_class": "GeoHealthCheck.plugins.probe.owsgetcaps.WmsGetCaps",
       "parameters": {
         "service": "WMS",
@@ -29,8 +29,8 @@
     }
   },
   "check_vars": {
-    "WOUDC WMS - GetCaps - XML Parse": {
-      "probe_vars": "WOUDC WMS - GetCaps",
+    "PDOK BAG WMS - GetCaps - XML Parse": {
+      "probe_vars": "PDOK BAG WMS - GetCaps",
       "check_class": "GeoHealthCheck.plugins.check.checks.XmlParse",
       "parameters": {}
     }


### PR DESCRIPTION
WOUDC WMS occasionally gives a failure on the WMS Drilldown Probe causing Travis to fail. Needs investigation, there's many Layers and the Probe will pick a random one. For now replace with PDOK BAG WMS that has just a few layers.