### PR TITLE
Dev #123 #124 #125 Probes using metadata and mapserver mapfile compat

### DIFF
--- a/GeoHealthCheck/app.py
+++ b/GeoHealthCheck/app.py
@@ -665,7 +665,7 @@ def edit_resource(resource_identifier):
         flash(gettext('Resource not found'), 'danger')
         return redirect(request.referrer)
 
-    probes_avail = views.get_probes_avail(resource.resource_type)
+    probes_avail = views.get_probes_avail(resource.resource_type, resource)
 
     return render_template('edit_resource.html', lang=g.current_lang,
                            resource=resource, probes_avail=probes_avail)
@@ -709,6 +709,7 @@ def get_probe_edit_form(probe_class):
     """get the form to edit a Probe"""
 
     probe_obj = Factory.create_obj(probe_class)
+
     probe_info = probe_obj.get_plugin_vars()
     probe_vars = ProbeVars(
         None, probe_class, probe_obj.get_default_parameter_values())

--- a/GeoHealthCheck/config_main.py
+++ b/GeoHealthCheck/config_main.py
@@ -89,7 +89,7 @@ GHC_PLUGINS = [
     # Probes
     'GeoHealthCheck.plugins.probe.owsgetcaps',
     'GeoHealthCheck.plugins.probe.wms',
-    'GeoHealthCheck.plugins.probe.wfs.WfsGetFeatureBbox',
+    'GeoHealthCheck.plugins.probe.wfs',
     'GeoHealthCheck.plugins.probe.tms',
     'GeoHealthCheck.plugins.probe.http',
     'GeoHealthCheck.plugins.probe.sta',

--- a/GeoHealthCheck/healthcheck.py
+++ b/GeoHealthCheck/healthcheck.py
@@ -64,7 +64,7 @@ def run_test_resource(resource):
 
 
 def sniff_test_resource(config, resource_type, url):
-    """tests a service and provides run metrics"""
+    """tests a Resource endpoint for general compliance"""
 
     if resource_type not in RESOURCE_TYPES.keys():
         msg = gettext('Invalid resource type')

--- a/GeoHealthCheck/healthcheck.py
+++ b/GeoHealthCheck/healthcheck.py
@@ -84,7 +84,7 @@ def sniff_test_resource(config, resource_type, url):
         elif resource_type == 'OSGeo:TMS':
             ows = TileMapService(url)
         elif resource_type == 'OGC:WFS':
-            ows = WebFeatureService(url)
+            ows = WebFeatureService(url, version='1.1.0')
         elif resource_type == 'OGC:WCS':
             ows = WebCoverageService(url, version='1.0.0')
         elif resource_type == 'OGC:WPS':

--- a/GeoHealthCheck/plugins/check/checks.py
+++ b/GeoHealthCheck/plugins/check/checks.py
@@ -2,6 +2,10 @@ import sys
 from owslib.etree import etree
 from GeoHealthCheck.plugin import Plugin
 from GeoHealthCheck.check import Check
+try:
+    from html import escape  # python 3.x
+except ImportError:
+    from cgi import escape  # python 2.x
 
 
 """ Contains basic Check classes for a Probe object."""
@@ -112,14 +116,19 @@ class HttpHasImageContentType(Check):
         result = True
         msg = 'OK'
         name = 'content-type'
-        headers = self.probe.response.headers
+        response = self.probe.response
+        headers = response.headers
         if name not in headers:
             result = False
             msg = 'HTTP response has no header %s' % name
         elif 'image/' not in headers[name]:
             result = False
             msg = 'HTTP response header %s is not image type' % name
-
+            if type(response.content) is str:
+                rsp_str = response.content
+                if len(rsp_str) > 256:
+                    rsp_str = rsp_str[-256:]
+                msg += ' - error: ' + escape(rsp_str)
         self.set_result(result, msg)
 
 

--- a/GeoHealthCheck/plugins/probe/http.py
+++ b/GeoHealthCheck/plugins/probe/http.py
@@ -17,6 +17,7 @@ class HttpGet(Probe):
         },
         'GeoHealthCheck.plugins.check.checks.ContainsStrings': {},
         'GeoHealthCheck.plugins.check.checks.NotContainsStrings': {},
+        'GeoHealthCheck.plugins.check.checks.HttpHasContentType': {}
     }
     """Checks avail"""
 

--- a/GeoHealthCheck/plugins/probe/tms.py
+++ b/GeoHealthCheck/plugins/probe/tms.py
@@ -156,7 +156,7 @@ class TmsGetTileAll(TmsGetTile):
         self.PARAM_DEFS['extension']['default'] = extension_val
 
     def before_request(self):
-        """ Perform actual request to service, overridden from base class"""
+        """ Before request to service, overridden from base class"""
 
         # Get capabilities doc to get all layers
         try:
@@ -171,8 +171,9 @@ class TmsGetTileAll(TmsGetTile):
         if not self.layers:
             self.result.set(False, 'Found no TMS Layers')
             return
-        
+
         self.result.start()
+
         results_failed_total = []
         for layer_name in self.layers.keys():
             # Layer name is last part of full URL

--- a/GeoHealthCheck/plugins/probe/tms.py
+++ b/GeoHealthCheck/plugins/probe/tms.py
@@ -111,7 +111,8 @@ class TmsGetTile(Probe):
             self.layer_count = len(layers)
 
             # Determine Layers and Extensions
-            layer_list = [layer_name.split('1.0.0/')[-1] for layer_name in layers]
+            layer_list = [layer_name.split('1.0.0/')[-1]
+                          for layer_name in layers]
             self.PARAM_DEFS['layer']['range'] = layer_list
 
             # Make a set of all extensions

--- a/GeoHealthCheck/plugins/probe/wfs.py
+++ b/GeoHealthCheck/plugins/probe/wfs.py
@@ -23,7 +23,7 @@ service="WFS"
 version="1.1.0"
 outputFormat="GML2"
 xsi:schemaLocation="http://www.opengis.net/wfs
-http://schemas.opengis.net/wfs/1.1.0/wfs.xsd" 
+http://schemas.opengis.net/wfs/1.1.0/wfs.xsd"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <wfs:Query typeName="{type_name}" srsName="{srs}"
         xmlns:{type_ns_prefix}="{type_ns_uri}">
@@ -124,20 +124,26 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             wfs = WebFeatureService(resource.url, version="1.1.0")
             feature_types = wfs.contents
             feature_type_names = list(feature_types.keys())
-            ft_namespaces = list(set([name.split(':')[0] if ':' in name else None for name in feature_type_names]))
-            ft_namespaces = filter(None, ft_namespaces)
+            ft_namespaces = set([name.split(':')[0] if ':' in name else None
+                                 for name in feature_type_names])
+            ft_namespaces = filter(None, list(ft_namespaces))
+
+            # In some cases default NS is used: no FT NSs
             if len(ft_namespaces) > 0:
                 nsmap = wfs._capabilities.nsmap
             else:
+                # Just use dummy NS, to satisfy REQUEST_TEMPLATE
                 ft_namespaces = ['notapplicable']
                 nsmap = {ft_namespaces[0]: 'http://not.appli.cable/'}
                 self.PARAM_DEFS['type_ns_prefix']['value'] = ft_namespaces[0]
-                self.PARAM_DEFS['type_ns_uri']['value'] = nsmap[ft_namespaces[0]]
+                self.PARAM_DEFS['type_ns_uri']['value'] = \
+                    nsmap[ft_namespaces[0]]
 
-            # Layers to select
+            # FeatureTypes to select
             self.PARAM_DEFS['type_name']['range'] = feature_type_names
             self.PARAM_DEFS['type_ns_prefix']['range'] = ft_namespaces
-            self.PARAM_DEFS['type_ns_uri']['range'] = [nsmap[ns] for ns in ft_namespaces]
+            self.PARAM_DEFS['type_ns_uri']['range'] = \
+                [nsmap[ns] for ns in ft_namespaces]
 
             # Image Format
             # for oper in wfs.operations:

--- a/GeoHealthCheck/plugins/probe/wfs.py
+++ b/GeoHealthCheck/plugins/probe/wfs.py
@@ -1,4 +1,5 @@
 from GeoHealthCheck.probe import Probe
+from GeoHealthCheck.plugin import Plugin
 from GeoHealthCheck.util import transform_bbox
 from owslib.wfs import WebFeatureService
 
@@ -191,6 +192,8 @@ class WfsGetFeatureBboxAll(WfsGetFeatureBbox):
     DESCRIPTION = """
         WFS GetFeature in BBOX for ALL FeatureTypes.
         """
+    # Copy all PARAM_DEFS from parent to have own instance
+    PARAM_DEFS = Plugin.merge(WfsGetFeatureBbox.PARAM_DEFS, {})
 
     def __init__(self):
         WfsGetFeatureBbox.__init__(self)

--- a/GeoHealthCheck/plugins/probe/wfs.py
+++ b/GeoHealthCheck/plugins/probe/wfs.py
@@ -1,4 +1,5 @@
 from GeoHealthCheck.probe import Probe
+from owslib.wfs import WebFeatureService
 
 
 class WfsGetFeatureBbox(Probe):
@@ -22,13 +23,12 @@ service="WFS"
 version="1.1.0"
 outputFormat="GML2"
 xsi:schemaLocation="http://www.opengis.net/wfs
-http://schemas.opengis.net/wfs/1.1.0/wfs.xsd"
+http://schemas.opengis.net/wfs/1.1.0/wfs.xsd" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <wfs:Query typeName="{type_name}" srsName="{srs}"
         xmlns:{type_ns_prefix}="{type_ns_uri}">
     <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
       <ogc:BBOX>
-        <ogc:PropertyName>{geom_property_name}</ogc:PropertyName>
         <gml:Envelope xmlns:gml="http://www.opengis.net/gml" srsName="{srs}">
           <gml:lowerCorner>{bbox[0]} {bbox[1]}</gml:lowerCorner>
           <gml:upperCorner>{bbox[2]} {bbox[3]}</gml:upperCorner>
@@ -47,7 +47,8 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             'type': 'string',
             'description': 'The WFS FeatureType name',
             'default': None,
-            'required': True
+            'required': True,
+            'range': None
         },
         'type_ns_prefix': {
             'type': 'string',
@@ -66,8 +67,9 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
         'geom_property_name': {
             'type': 'string',
             'description': 'Name of the geometry property within FeatureType',
-            'default': 'the_geom',
+            'default': None,
             'required': True,
+            'value': 'Not Required',
             'range': None
         },
         'srs': {
@@ -112,3 +114,52 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     Optionally override Check PARAM_DEFS using set_params
     e.g. with specific `value` or even `name`.
     """
+
+    # Overridden: expand param-ranges from WMS metadata
+    def expand_params(self, resource):
+
+        # Use WMS Capabilities doc to get metadata for
+        # PARAM_DEFS ranges/defaults
+        try:
+            wfs = WebFeatureService(resource.url, version="1.1.0")
+            feature_types = wfs.contents
+            feature_type_names = list(feature_types.keys())
+            ft_namespaces = list(set([name.split(':')[0] if ':' in name else None for name in feature_type_names]))
+            ft_namespaces = filter(None, ft_namespaces)
+            if len(ft_namespaces) > 0:
+                nsmap = wfs._capabilities.nsmap
+            else:
+                ft_namespaces = ['notapplicable']
+                nsmap = {ft_namespaces[0]: 'http://not.appli.cable/'}
+                self.PARAM_DEFS['type_ns_prefix']['value'] = ft_namespaces[0]
+                self.PARAM_DEFS['type_ns_uri']['value'] = nsmap[ft_namespaces[0]]
+
+            # Layers to select
+            self.PARAM_DEFS['type_name']['range'] = feature_type_names
+            self.PARAM_DEFS['type_ns_prefix']['range'] = ft_namespaces
+            self.PARAM_DEFS['type_ns_uri']['range'] = [nsmap[ns] for ns in ft_namespaces]
+
+            # Image Format
+            # for oper in wfs.operations:
+            #     if oper.name == 'GetFeature':
+            #         self.PARAM_DEFS['format']['range'] = \
+            #             oper.formatOptions
+            #         break
+
+            # Take first feature_type to determine generic attrs
+            feature_type_name, feature_type_entry = feature_types.popitem()
+
+            # SRS
+            crs_list = feature_type_entry.crsOptions
+            srs_range = ['EPSG:%s' % crs.code for crs in crs_list]
+            self.PARAM_DEFS['srs']['range'] = srs_range
+
+            # bbox list: 0-3 is bbox, 4 is SRS
+            bbox = feature_type_entry.boundingBoxWGS84
+            self.PARAM_DEFS['srs']['default'] = srs_range[0]
+            self.PARAM_DEFS['bbox']['default'] = \
+                ['{:.2f}'.format(x) for x in bbox]
+
+            # self.PARAM_DEFS['exceptions']['range'] = wfs.exceptions
+        except Exception as err:
+            raise err

--- a/GeoHealthCheck/plugins/probe/wms.py
+++ b/GeoHealthCheck/plugins/probe/wms.py
@@ -1,4 +1,5 @@
 from GeoHealthCheck.probe import Probe
+# from GeoHealthCheck.util import transform_bbox
 from owslib.wms import WebMapService
 
 
@@ -124,125 +125,13 @@ class WmsGetMapV1(Probe):
             bbox = layer_entry.boundingBox
             bbox_srs = bbox[4]
             self.PARAM_DEFS['srs']['default'] = bbox_srs
+            # if it is not EPSG:4326 we need to transform bbox
+            # if bbox_srs != 'EPSG:4326':
+            #     bbox = transform_bbox('EPSG:4326', bbox_srs, bbox[:-1])
+
             self.PARAM_DEFS['bbox']['default'] = \
                 ['{:.2f}'.format(x) for x in bbox[:-1]]
 
             self.PARAM_DEFS['exceptions']['range'] = wms.exceptions
         except Exception as err:
             self.result.set(False, str(err))
-
-
-class WmsGetMapV1All(WmsGetMapV1):
-    """
-    Get WMS map image for each Layer using the WMS GetMap operation.
-    """
-
-    NAME = 'WMS GetMap WMS v1.1.1. operation (all Layers)'
-    DESCRIPTION = """
-    Do WMS GetMap v1.1.1 request for all Layers with
-    user-specified parameters.
-    """
-    RESOURCE_TYPE = 'OGC:WMS'
-
-    REQUEST_METHOD = 'GET'
-    REQUEST_TEMPLATE = '?SERVICE=WMS&VERSION=1.1.1&' + \
-                       'REQUEST=GetMap&LAYERS={layers}&SRS={srs}&' + \
-                       'BBOX={bbox[0]},{bbox[1]},{bbox[2]},{bbox[3]}&' + \
-                       'WIDTH={width}&HEIGHT={height}&FORMAT={format}' + \
-                       '&STYLES={styles}&EXCEPTIONS={exceptions}'
-
-    PARAM_DEFS = {
-        'layers': {
-            'type': 'stringlist',
-            'description': 'The WMS Layers, all',
-            'default': ['*'],
-            'value': ['*'],
-            'required': True,
-            'range': ['*']
-        },
-        'srs': {
-            'type': 'string',
-            'description': 'The SRS as EPSG: code',
-            'default': 'EPSG:4326',
-            'required': True,
-            'range': None
-        },
-        'bbox': {
-            'type': 'bbox',
-            'description': 'The WMS bounding box',
-            'default': ['-180', '-90', '180', '90'],
-            'required': True,
-            'range': None
-        },
-        'width': {
-            'type': 'string',
-            'description': 'The image width',
-            'default': '256',
-            'required': True
-        },
-        'height': {
-            'type': 'string',
-            'description': 'The image height',
-            'default': '256',
-            'required': True
-        },
-        'format': {
-            'type': 'string',
-            'description': 'The image format',
-            'default': 'image/png',
-            'required': True
-        },
-        'styles': {
-            'type': 'string',
-            'description': 'The Styles to apply',
-            'default': None,
-            'required': False
-        },
-        'exceptions': {
-            'type': 'string',
-            'description': 'The Exception format to use',
-            'default': 'application/vnd.ogc.se_xml',
-            'required': True
-        }
-
-    }
-    """Param defs"""
-
-    CHECKS_AVAIL = {
-        'GeoHealthCheck.plugins.check.checks.HttpHasImageContentType': {
-            'default': True
-        },
-        'GeoHealthCheck.plugins.check.checks.NotContainsOwsException': {
-            'default': True
-        }
-    }
-    """
-    Checks for WMS GetMap Response available.
-    Optionally override Check PARAM_DEFS using set_params
-    e.g. with specific `value` or even `name`.
-    """
-
-    def perform_request(self):
-        """ Perform actual request to service, overridden from base class"""
-        layers = self._parameters['layers']
-        if len(layers) == 0 or (len(layers) == 1 and layers[0] == ''):
-            # Get capabilities doc, parses
-            try:
-                wms = WebMapService(self._resource.url)
-                layers = wms.contents.keys()
-            except Exception as err:
-                self.result.set(False, str(err))
-                return
-
-        for layer in layers:
-            self._parameters['layers'] = [layer]
-            Probe.perform_request(self)
-            self.run_checks()
-            # Only keep failed layer results
-            results_failed = self.result.results_failed
-            if len(results_failed) > 0:
-                # We have a failed layer: add to result message
-                for result in results_failed:
-                    result.message = 'layer %s: ' % layer + result.message
-            else:
-                self.result.results = []

--- a/GeoHealthCheck/plugins/probe/wms.py
+++ b/GeoHealthCheck/plugins/probe/wms.py
@@ -130,3 +130,119 @@ class WmsGetMapV1(Probe):
             self.PARAM_DEFS['exceptions']['range'] = wms.exceptions
         except Exception as err:
             self.result.set(False, str(err))
+
+
+class WmsGetMapV1All(WmsGetMapV1):
+    """
+    Get WMS map image for each Layer using the WMS GetMap operation.
+    """
+
+    NAME = 'WMS GetMap WMS v1.1.1. operation (all Layers)'
+    DESCRIPTION = """
+    Do WMS GetMap v1.1.1 request for all Layers with
+    user-specified parameters.
+    """
+    RESOURCE_TYPE = 'OGC:WMS'
+
+    REQUEST_METHOD = 'GET'
+    REQUEST_TEMPLATE = '?SERVICE=WMS&VERSION=1.1.1&' + \
+                       'REQUEST=GetMap&LAYERS={layers}&SRS={srs}&' + \
+                       'BBOX={bbox[0]},{bbox[1]},{bbox[2]},{bbox[3]}&' + \
+                       'WIDTH={width}&HEIGHT={height}&FORMAT={format}' + \
+                       '&STYLES={styles}&EXCEPTIONS={exceptions}'
+
+    PARAM_DEFS = {
+        'layers': {
+            'type': 'stringlist',
+            'description': 'The WMS Layers, all',
+            'default': ['*'],
+            'value': ['*'],
+            'required': True,
+            'range': ['*']
+        },
+        'srs': {
+            'type': 'string',
+            'description': 'The SRS as EPSG: code',
+            'default': 'EPSG:4326',
+            'required': True,
+            'range': None
+        },
+        'bbox': {
+            'type': 'bbox',
+            'description': 'The WMS bounding box',
+            'default': ['-180', '-90', '180', '90'],
+            'required': True,
+            'range': None
+        },
+        'width': {
+            'type': 'string',
+            'description': 'The image width',
+            'default': '256',
+            'required': True
+        },
+        'height': {
+            'type': 'string',
+            'description': 'The image height',
+            'default': '256',
+            'required': True
+        },
+        'format': {
+            'type': 'string',
+            'description': 'The image format',
+            'default': 'image/png',
+            'required': True
+        },
+        'styles': {
+            'type': 'string',
+            'description': 'The Styles to apply',
+            'default': None,
+            'required': False
+        },
+        'exceptions': {
+            'type': 'string',
+            'description': 'The Exception format to use',
+            'default': 'application/vnd.ogc.se_xml',
+            'required': True
+        }
+
+    }
+    """Param defs"""
+
+    CHECKS_AVAIL = {
+        'GeoHealthCheck.plugins.check.checks.HttpHasImageContentType': {
+            'default': True
+        },
+        'GeoHealthCheck.plugins.check.checks.NotContainsOwsException': {
+            'default': True
+        }
+    }
+    """
+    Checks for WMS GetMap Response available.
+    Optionally override Check PARAM_DEFS using set_params
+    e.g. with specific `value` or even `name`.
+    """
+
+    def perform_request(self):
+        """ Perform actual request to service, overridden from base class"""
+        layers = self._parameters['layers']
+        if len(layers) == 0 or (len(layers) == 1 and layers[0] == ''):
+            # Get capabilities doc, parses
+            try:
+                wms = WebMapService(self._resource.url)
+                layers = wms.contents.keys()
+            except Exception as err:
+                self.result.set(False, str(err))
+                return
+
+        for layer in layers:
+            self._parameters['layers'] = [layer]
+            Probe.perform_request(self)
+            self.run_checks()
+            # Only keep failed layer results
+            results_failed = self.result.results_failed
+            if len(results_failed) > 0:
+                # We have a failed layer: add to result message
+                for result in results_failed:
+                    result.message = 'layer %s: ' % layer + result.message
+            else:
+                self.result.results = []

--- a/GeoHealthCheck/plugins/probe/wms.py
+++ b/GeoHealthCheck/plugins/probe/wms.py
@@ -1,13 +1,18 @@
 from GeoHealthCheck.probe import Probe
+from owslib.wms import WebMapService
 
 
 class WmsGetMapV1(Probe):
     """
-    Get WMS map image using the WMS GetMap operation.
+    Get WMS map image using the OGC WMS GetMap v1.1.1 Operation
+    for single Layer.
     """
 
-    NAME = 'WMS GetMap WMS v1.1.1. operation'
-    DESCRIPTION = 'Do WMS GetMap v1.1.1 request with user-specified parameters'
+    NAME = 'WMS GetMap WMS v1.1.1. operation (single Layer)'
+    DESCRIPTION = """
+    Do WMS GetMap v1.1.1 request with user-specified parameters
+    for single Layer. Ranges and defaults from WMS Capabilities.
+    """
     RESOURCE_TYPE = 'OGC:WMS'
 
     REQUEST_METHOD = 'GET'
@@ -17,13 +22,10 @@ class WmsGetMapV1(Probe):
                        'WIDTH={width}&HEIGHT={height}&FORMAT={format}' + \
                        '&STYLES={styles}&EXCEPTIONS={exceptions}'
 
-    def __init__(self):
-        Probe.__init__(self)
-
     PARAM_DEFS = {
         'layers': {
             'type': 'stringlist',
-            'description': 'The WMS Layers, comma separated',
+            'description': 'The WMS Layer, select one',
             'default': [],
             'required': True,
             'range': None
@@ -58,7 +60,8 @@ class WmsGetMapV1(Probe):
             'type': 'string',
             'description': 'The image format',
             'default': 'image/png',
-            'required': True
+            'required': True,
+            'range': None
         },
         'styles': {
             'type': 'string',
@@ -70,7 +73,8 @@ class WmsGetMapV1(Probe):
             'type': 'string',
             'description': 'The Exception format to use',
             'default': 'application/vnd.ogc.se_xml',
-            'required': True
+            'required': True,
+            'range': None
         }
 
     }
@@ -89,3 +93,40 @@ class WmsGetMapV1(Probe):
     Optionally override Check PARAM_DEFS using set_params
     e.g. with specific `value` or even `name`.
     """
+
+    # Overridden: expand param-ranges from WMS metadata
+    def expand_params(self, resource):
+
+        # Use WMS Capabilities doc to get metadata for
+        # PARAM_DEFS ranges/defaults
+        try:
+            wms = WebMapService(resource.url)
+            layers = wms.contents
+
+            # Layers to select
+            self.PARAM_DEFS['layers']['range'] = list(layers.keys())
+
+            # Image Format
+            for oper in wms.operations:
+                if oper.name == 'GetMap':
+                    self.PARAM_DEFS['format']['range'] = \
+                        oper.formatOptions
+                    break
+
+            # Take first layer to determine generic attrs
+            layer_name, layer_entry = layers.popitem()
+
+            # SRS
+            srs_range = layer_entry.crsOptions
+            self.PARAM_DEFS['srs']['range'] = srs_range
+
+            # bbox list: 0-3 is bbox, 4 is SRS
+            bbox = layer_entry.boundingBox
+            bbox_srs = bbox[4]
+            self.PARAM_DEFS['srs']['default'] = bbox_srs
+            self.PARAM_DEFS['bbox']['default'] = \
+                ['{:.2f}'.format(x) for x in bbox[:-1]]
+
+            self.PARAM_DEFS['exceptions']['range'] = wms.exceptions
+        except Exception as err:
+            self.result.set(False, str(err))

--- a/GeoHealthCheck/plugins/probe/wms.py
+++ b/GeoHealthCheck/plugins/probe/wms.py
@@ -1,4 +1,5 @@
 from GeoHealthCheck.probe import Probe
+from GeoHealthCheck.plugin import Plugin
 from owslib.wms import WebMapService
 
 
@@ -151,6 +152,8 @@ class WmsGetMapV1All(WmsGetMapV1):
     Do WMS GetMap v1.1.1 request for all Layers with
     user-specified parameters.
     """
+    # Copy all PARAM_DEFS from parent to have own instance
+    PARAM_DEFS = Plugin.merge(WmsGetMapV1.PARAM_DEFS, {})
 
     def __init__(self):
         WmsGetMapV1.__init__(self)

--- a/GeoHealthCheck/probe.py
+++ b/GeoHealthCheck/probe.py
@@ -171,9 +171,11 @@ class Probe(Plugin):
         request_string = None
         if self.REQUEST_TEMPLATE:
             request_string = self.REQUEST_TEMPLATE
+            if '?' in url_base and self.REQUEST_TEMPLATE[0] == '?':
+                self.REQUEST_TEMPLATE = '&' + self.REQUEST_TEMPLATE[1:]
 
-            if self._probe_vars.parameters:
-                request_parms = self._probe_vars.parameters
+            if self._parameters:
+                request_parms = self._parameters
                 param_defs = self.get_param_defs()
 
                 # Expand string list array to comma separated string

--- a/GeoHealthCheck/probe.py
+++ b/GeoHealthCheck/probe.py
@@ -70,6 +70,11 @@ class Probe(Plugin):
     def __init__(self):
         Plugin.__init__(self)
 
+    #
+    # Lifecycle : optionally expand params from Resource metadata
+    def expand_params(self, resource):
+        pass
+
     # Lifecycle
     def init(self, resource, probe_vars):
         """
@@ -81,9 +86,11 @@ class Probe(Plugin):
         :return: None
         """
         self._resource = resource
+
         self._probe_vars = probe_vars
         self._parameters = probe_vars.parameters
         self._check_vars = probe_vars.check_vars
+
         self.response = None
 
         # Create ProbeResult object that gathers all results for single Probe

--- a/GeoHealthCheck/probe.py
+++ b/GeoHealthCheck/probe.py
@@ -222,11 +222,11 @@ class Probe(Plugin):
     def run_request(self):
         """ Run actual request to service"""
         try:
-            self.result.start()
             self.before_request()
+            self.result.start()
             self.perform_request()
-            self.after_request()
             self.result.stop()
+            self.after_request()
         except:
             # We must never bailout because of Exception
             # in Probe.

--- a/GeoHealthCheck/probe.py
+++ b/GeoHealthCheck/probe.py
@@ -73,6 +73,12 @@ class Probe(Plugin):
     #
     # Lifecycle : optionally expand params from Resource metadata
     def expand_params(self, resource):
+        """
+        Called after creation. Use to expand PARAM_DEFS, e.g. from Resource
+        metadata like WMS Capabilities. See e.g. WmsGetMapV1 class.
+        :param resource:
+        :return: None
+        """
         pass
 
     # Lifecycle

--- a/GeoHealthCheck/util.py
+++ b/GeoHealthCheck/util.py
@@ -165,3 +165,18 @@ def geocode(value, spatial_keyword_type='hostname'):
             LOGGER.exception(msg)
             raise ValueError(msg)
     return []
+
+
+def transform_bbox(epsg1, epsg2, bbox):
+    """
+    convenience function to transform a bbox array
+    """
+
+    import pyproj
+
+    p1 = pyproj.Proj(init=epsg1)
+    p2 = pyproj.Proj(init=epsg2)
+    ll = pyproj.transform(p1, p2, bbox[0], bbox[1])
+    ul = pyproj.transform(p1, p2, bbox[2], bbox[3])
+
+    return list(ll) + list(ul)

--- a/GeoHealthCheck/views.py
+++ b/GeoHealthCheck/views.py
@@ -147,10 +147,11 @@ def get_query_field_term(query):
     return [field, term]
 
 
-def get_probes_avail(resource_type=None):
+def get_probes_avail(resource_type=None, resource=None):
     """
     Get all available Probes with their attributes.
     :param resource_type: optional resource type e.g. OGC:WMS
+    :param resource: optional Resource instance
     :return:
     """
 
@@ -165,6 +166,8 @@ def get_probes_avail(resource_type=None):
     result = dict()
     for probe_class in probe_classes:
         probe = Factory.create_obj(probe_class)
+        if resource:
+            probe.expand_params(resource)
         result[probe_class] = probe.get_plugin_vars()
 
     return result

--- a/tests/data/fixtures.json
+++ b/tests/data/fixtures.json
@@ -36,7 +36,7 @@
       "owner": "admin",
       "resource_type": "OGC:WFS",
       "title": "PDOK BAG Web Feature Service",
-      "url": "https://geodata.nationaalgeoregister.nl/bag/wfs",
+      "url": "http://geodata.nationaalgeoregister.nl/bag/wfs",
       "tags": [
         "ows",
         "pdok"
@@ -108,10 +108,11 @@
         "layers": ["*"],
         "styles": "",
         "format": "image/png",
+        "width": "256",
         "height": "256",
         "srs": "EPSG:28992",
         "bbox": ["180635", "455870", "180961", "456050"],
-        "exceptions": "application/vnd.ogc.se_xml", "width": "256"
+        "exceptions": "application/vnd.ogc.se_xml"
       }
     },
     "PDOK BAG WMS - Drilldown": {
@@ -133,10 +134,20 @@
       "resource": "PDOK BAG WFS",
       "probe_class": "GeoHealthCheck.plugins.probe.wfs.WfsGetFeatureBbox",
       "parameters": {
-        "type_name": "verblijfsobject:verblijfsobject",
-        "type_ns_prefix": "verblijfsobject",
+        "type_name": "bag:verblijfsobject",
+        "type_ns_prefix": "bag",
         "type_ns_uri": "http://bag.geonovum.nl",
-        "geom_property_name": "geometrie",
+        "srs": "EPSG:28992",
+        "bbox": ["180635", "455870", "180961", "456050"]
+      }
+    },
+    "PDOK BAG WFS - GetFeature All": {
+      "resource": "PDOK BAG WFS",
+      "probe_class": "GeoHealthCheck.plugins.probe.wfs.WfsGetFeatureBboxAll",
+      "parameters": {
+        "type_name": "all 5 featuretypes",
+        "type_ns_prefix": "bag",
+        "type_ns_uri": "http://bag.geonovum.nl",
         "srs": "EPSG:28992",
         "bbox": ["180635", "455870", "180961", "456050"]
       }
@@ -221,7 +232,26 @@
       "probe_vars": "PDOK BAG WFS - GetFeature",
       "check_class": "GeoHealthCheck.plugins.check.checks.ContainsStrings",
       "parameters": {
-        "strings": ["FeatureCollection>"]
+        "strings": ["FeatureCollection"]
+      }
+    },
+    "PDOK BAG WFS - GetFeature All - XML Parse": {
+      "probe_vars": "PDOK BAG WFS - GetFeature All",
+      "check_class": "GeoHealthCheck.plugins.check.checks.XmlParse",
+      "parameters": {}
+    },
+    "PDOK BAG WFS - GetFeature All - No Exception": {
+      "probe_vars": "PDOK BAG WFS - GetFeature All",
+      "check_class": "GeoHealthCheck.plugins.check.checks.NotContainsOwsException",
+      "parameters": {
+        "strings": ["ExceptionReport>", "ServiceException>"]
+      }
+    },
+    "PDOK BAG WFS - GetFeature All - FeatureCollection": {
+      "probe_vars": "PDOK BAG WFS - GetFeature All",
+      "check_class": "GeoHealthCheck.plugins.check.checks.ContainsStrings",
+      "parameters": {
+        "strings": ["FeatureCollection"]
       }
     },
     "WOUDC CSW - GetCaps - XML Parse": {

--- a/tests/data/fixtures.json
+++ b/tests/data/fixtures.json
@@ -88,6 +88,32 @@
         "version": "1.0.0"
       }
     },
+    "PDOK BAG WMS - GetMap Single": {
+      "resource": "PDOK BAG WMS",
+      "probe_class": "GeoHealthCheck.plugins.probe.wms.WmsGetMapV1",
+      "parameters": {
+        "layers": ["ligplaats"],
+        "styles": "",
+        "format": "image/png",
+        "height": "256",
+        "srs": "EPSG:28992",
+        "bbox": ["180635", "455870", "180961", "456050"],
+        "exceptions": "application/vnd.ogc.se_xml", "width": "256"
+      }
+    },
+    "PDOK BAG WMS - GetMap All": {
+      "resource": "PDOK BAG WMS",
+      "probe_class": "GeoHealthCheck.plugins.probe.wms.WmsGetMapV1All",
+      "parameters": {
+        "layers": ["*"],
+        "styles": "",
+        "format": "image/png",
+        "height": "256",
+        "srs": "EPSG:28992",
+        "bbox": ["180635", "455870", "180961", "456050"],
+        "exceptions": "application/vnd.ogc.se_xml", "width": "256"
+      }
+    },
     "PDOK BAG WMS - Drilldown": {
       "resource": "PDOK BAG WMS",
       "probe_class": "GeoHealthCheck.plugins.probe.wmsdrilldown.WmsDrilldown",
@@ -162,6 +188,16 @@
     "PDOK BAG WMS - GetCaps - XML Parse": {
       "probe_vars": "PDOK BAG WMS - GetCaps",
       "check_class": "GeoHealthCheck.plugins.check.checks.XmlParse",
+      "parameters": {}
+    },
+    "PDOK BAG WMS - GetMap Single - Has Image": {
+      "probe_vars": "PDOK BAG WMS - GetMap Single",
+      "check_class": "GeoHealthCheck.plugins.check.checks.HttpHasImageContentType",
+      "parameters": {}
+    },
+    "PDOK BAG WMS - GetMap All - Has Image": {
+      "probe_vars": "PDOK BAG WMS - GetMap All",
+      "check_class": "GeoHealthCheck.plugins.check.checks.HttpHasImageContentType",
       "parameters": {}
     },
     "WOUDC WFS - GetCaps - XML Parse": {

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -64,7 +64,7 @@ class GeoHealthCheckTest(unittest.TestCase):
         resources = Resource.query.all()
         for resource in resources:
             result = run_test_resource(resource)
-
+            print('resource: %s result=%s' % (resource.url, result.success))
             run = Run(resource, result)
 
             print('Adding Run: success=%s, response_time=%ss\n'


### PR DESCRIPTION
These are commits from 3 issues. #124 is just to be able to add a Resource URL that already contains a `?`, e.g. a `MapServer` mapfile. 

#123 and #125 deal with existing and new `Probes` that use a Resource metadata, read `Capabilities`, to provide easier fill-in forms. e.g. select a Layer from prefilled Layer combo-box. #125 are 3 new Probes to perform requests on each Layer/Feature Type. Saves a lot of filling in separate layers. e.g. PDOK TMS has 55 layers that are all accessed/tested in single Probe Run.

Moving to master now and going into maintenance mode....