### PR TITLE
add option to disable a resource (#161)

### DIFF
--- a/GeoHealthCheck/app.py
+++ b/GeoHealthCheck/app.py
@@ -656,7 +656,10 @@ def test(resource_identifier):
         resource)
 
     if request.method == 'GET':
-        if result.message not in ['OK', None, 'None']:
+        if result.message == 'Skipped':
+            msg = gettext('INFO')
+            flash('%s: %s' % (msg, result.message), 'info')
+        elif result.message not in ['OK', None, 'None']:
             msg = gettext('ERROR')
             flash('%s: %s' % (msg, result.message), 'danger')
         else:

--- a/GeoHealthCheck/healthcheck.py
+++ b/GeoHealthCheck/healthcheck.py
@@ -53,6 +53,9 @@ def run_test_resource(resource):
     """tests a service and provides run metrics"""
 
     result = ResourceResult(resource)
+    if not resource.active:
+        result.message = 'Skipped'
+        return result
     result.start()
     probes = resource.probe_vars
     for probe in probes:

--- a/GeoHealthCheck/migrations/README.md
+++ b/GeoHealthCheck/migrations/README.md
@@ -58,3 +58,9 @@ Changes:
 
 * create two new tables: `probe_vars` and `check_vars`
 * add column `report` to `run` table
+
+### 2638c2a40625 - Add resource.active column
+
+Changes:
+
+* add column `active` to `resource` table

--- a/GeoHealthCheck/migrations/versions/2638c2a40625_.py
+++ b/GeoHealthCheck/migrations/versions/2638c2a40625_.py
@@ -1,0 +1,35 @@
+"""empty message
+
+Revision ID: 2638c2a40625
+Revises: 992013af402f
+Create Date: 2017-09-08 10:48:19.596099
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2638c2a40625'
+down_revision = '992013af402f'
+branch_labels = None
+depends_on = None
+
+alembic_helpers = imp.load_source('alembic_helpers', (
+os.getcwd() + '/' + op.get_context().script.dir + '/alembic_helpers.py'))
+
+def upgrade():
+    if not alembic_helpers.table_has_column('resource', 'active'):
+        from sqlalchemy.sql import table, column
+        print('Column active not present in resource table, will create')
+        op.add_column(u'resource', sa.Column('active', sa.Boolean, nullable=True, default=True))
+        resource = table('resource', column('active'))
+        op.execute(resource.update().values(active=True))
+        op.alter_column('resource', 'active', nullable=False)
+    else:
+        print('Column active already present in resource table')
+
+
+def downgrade():
+    print('Dropping Column active from resource table')
+    op.drop_column(u'resource', 'active')

--- a/GeoHealthCheck/models.py
+++ b/GeoHealthCheck/models.py
@@ -191,6 +191,7 @@ class Resource(DB.Model):
 
     identifier = DB.Column(DB.Integer, primary_key=True, autoincrement=True)
     resource_type = DB.Column(DB.Text, nullable=False)
+    active = DB.Column(DB.Boolean, nullable=False, default=True)
     title = DB.Column(DB.Text, nullable=False)
     url = DB.Column(DB.Text, nullable=False)
     latitude = DB.Column(DB.Float)
@@ -202,6 +203,7 @@ class Resource(DB.Model):
 
     def __init__(self, owner, resource_type, title, url, tags):
         self.resource_type = resource_type
+        self.active = True
         self.title = title
         self.url = url
         self.owner = owner
@@ -559,6 +561,10 @@ if __name__ == '__main__':
             for resource in Resource.query.all():  # run all tests
                 print('Testing %s %s' %
                       (resource.resource_type, resource.url))
+
+                if not resource.active:
+                    print('Resource is not active. Skipping')
+                    continue
 
                 # Get the status of the last run,
                 # assume success if there is none

--- a/GeoHealthCheck/templates/edit_resource.html
+++ b/GeoHealthCheck/templates/edit_resource.html
@@ -11,6 +11,14 @@
                 <td>{{ resource_types[resource.resource_type]['label'] }}</td>
             </tr>
             <tr>
+                <th>
+                    {{ _('Active') }}
+                </th>
+                <td>
+                    <input type="checkbox" id="input_resource_active" name="resource_active_value" {{ 'checked' if resource.active == true else '' }}/>
+                </td>
+            </tr>
+            <tr>
                 <th>{{ _('Owner') }}</th>
                 <td>{{ resource.owner.username }}</td>
             </tr>
@@ -197,6 +205,9 @@
         // Collect tags
         var new_tags = $('#resource_tags').val();
 
+        // Collect active
+        var new_active = $('#input_resource_active').prop('checked');
+
         // Collect Probes with parameters and contained Checks
         // also with parameters
         var new_probes = [];
@@ -257,6 +268,7 @@
             url: "{{ url_for('update', resource_identifier=resource.identifier) }}",
             data: JSON.stringify({
                 title: new_title,
+                active: new_active,
                 tags: new_tags,
                 probes: new_probes
             }),

--- a/GeoHealthCheck/templates/resource.html
+++ b/GeoHealthCheck/templates/resource.html
@@ -27,6 +27,10 @@
                 <td>{{ resource_types[resource.resource_type]['label'] }}</td>
             </tr>
             <tr>
+                <th>{{ _('Active') }}</th>
+                <td>{{ resource.active }}</td>
+            </tr>
+            <tr>
                 <th>{{ _('Owner') }}</th>
                 <td>{{ resource.owner.username }}</td>
             </tr>

--- a/GeoHealthCheck/translations/de/LC_MESSAGES/messages.po
+++ b/GeoHealthCheck/translations/de/LC_MESSAGES/messages.po
@@ -345,3 +345,6 @@ msgstr ""
 
 msgid "Enter tags"
 msgstr ""
+
+msgid "Active"
+msgstr ""

--- a/GeoHealthCheck/translations/de_DE/LC_MESSAGES/messages.po
+++ b/GeoHealthCheck/translations/de_DE/LC_MESSAGES/messages.po
@@ -345,3 +345,6 @@ msgstr ""
 
 msgid "Enter tags"
 msgstr ""
+
+msgid "Active"
+msgstr ""

--- a/GeoHealthCheck/translations/en/LC_MESSAGES/messages.po
+++ b/GeoHealthCheck/translations/en/LC_MESSAGES/messages.po
@@ -339,3 +339,6 @@ msgstr ""
 
 msgid "Enter tags"
 msgstr ""
+
+msgid "Active"
+msgstr ""

--- a/GeoHealthCheck/translations/es_BO/LC_MESSAGES/messages.po
+++ b/GeoHealthCheck/translations/es_BO/LC_MESSAGES/messages.po
@@ -371,3 +371,6 @@ msgstr ""
 
 msgid "Enter tags"
 msgstr ""
+
+msgid "Active"
+msgstr ""

--- a/GeoHealthCheck/translations/fr/LC_MESSAGES/messages.po
+++ b/GeoHealthCheck/translations/fr/LC_MESSAGES/messages.po
@@ -344,3 +344,6 @@ msgstr ""
 
 msgid "Enter tags"
 msgstr ""
+
+msgid "Active"
+msgstr ""

--- a/GeoHealthCheck/translations/nl_NL/LC_MESSAGES/messages.po
+++ b/GeoHealthCheck/translations/nl_NL/LC_MESSAGES/messages.po
@@ -343,3 +343,6 @@ msgstr ""
 
 msgid "Enter tags"
 msgstr ""
+
+msgid "Active"
+msgstr ""

--- a/tests/data/fixtures.json
+++ b/tests/data/fixtures.json
@@ -16,6 +16,7 @@
     "PDOK BAG WMS": {
       "owner": "admin",
       "resource_type": "OGC:WMS",
+      "active": true,
       "title": "PDOK BAG Web Map Service",
       "url": "http://geodata.nationaalgeoregister.nl/bag/wms",
       "tags": [
@@ -26,6 +27,7 @@
     "WOUDC WFS": {
       "owner": "admin",
       "resource_type": "OGC:WFS",
+      "active": true,
       "title": "WOUDC Web Feature Service",
       "url": "http://geo.woudc.org/ows",
       "tags": [
@@ -35,6 +37,7 @@
     "PDOK BAG WFS": {
       "owner": "admin",
       "resource_type": "OGC:WFS",
+      "active": true,
       "title": "PDOK BAG Web Feature Service",
       "url": "http://geodata.nationaalgeoregister.nl/bag/wfs",
       "tags": [
@@ -45,6 +48,7 @@
     "WOUDC CSW": {
       "owner": "admin",
       "resource_type": "OGC:CSW",
+      "active": true,
       "title": "WOUDC Catalogue Service",
       "url": "http://geo.woudc.org/csw",
       "tags": [
@@ -54,6 +58,7 @@
     "WOUDC WMTS": {
       "owner": "admin",
       "resource_type": "OGC:WMTS",
+      "active": true,
       "title": "NASA Global Imagery Browse Services for EOSDIS",
       "url": "http://map1c.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi",
       "tags": [
@@ -64,6 +69,7 @@
     "WOUDC LINK": {
       "owner": "admin",
       "resource_type": "WWW:LINK",
+      "active": true,
       "title": "WOUDC Definitions Service",
       "url": "http://geo.woudc.org/def",
       "tags": []
@@ -71,6 +77,7 @@
     "PDOK TMS": {
       "owner": "admin",
       "resource_type": "OSGeo:TMS",
+      "active": true,
       "title": "Tile Map Service",
       "url": "http://geodata.nationaalgeoregister.nl/tiles/service/tms/1.0.0",
       "tags": [

--- a/tests/data/minimal.json
+++ b/tests/data/minimal.json
@@ -13,6 +13,7 @@
     "PDOK BAG WMS": {
       "owner": "admin",
       "resource_type": "OGC:WMS",
+      "active": true,
       "title": "PDOK BAG Web Map Service",
       "url": "http://geodata.nationaalgeoregister.nl/bag/wms",
       "tags": []


### PR DESCRIPTION
Implements #161.

@justb4 I wasn't able to create the alembic migrations (as per https://github.com/geopython/GeoHealthCheck/tree/master/GeoHealthCheck/migrations/README.md):

```bash
(GeoHealthCheck)tkralidi@www:~/work/foss4g/GeoHealthCheck/GeoHealthCheck/GeoHealthCheck$ python manage.py db migrate
init.py: created GHC App instance
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
Traceback (most recent call last):
  File "manage.py", line 53, in <module>
    manager.run()
  File "/home/tkralidi/work/foss4g/GeoHealthCheck/local/lib/python2.7/site-packages/flask_script/__init__.py", line 412, in run
    result = self.handle(sys.argv[0], sys.argv[1:])
  File "/home/tkralidi/work/foss4g/GeoHealthCheck/local/lib/python2.7/site-packages/flask_script/__init__.py", line 383, in handle
    res = handle(*args, **config)
  File "/home/tkralidi/work/foss4g/GeoHealthCheck/local/lib/python2.7/site-packages/flask_script/commands.py", line 216, in __call__
    return self.run(*args, **kwargs)
  File "/home/tkralidi/work/foss4g/GeoHealthCheck/local/lib/python2.7/site-packages/flask_migrate/__init__.py", line 182, in migrate
    version_path=version_path, rev_id=rev_id)
  File "/home/tkralidi/work/foss4g/GeoHealthCheck/local/lib/python2.7/site-packages/alembic/command.py", line 176, in revision
    script_directory.run_env()
  File "/home/tkralidi/work/foss4g/GeoHealthCheck/local/lib/python2.7/site-packages/alembic/script/base.py", line 425, in run_env
    util.load_python_file(self.dir, 'env.py')
  File "/home/tkralidi/work/foss4g/GeoHealthCheck/local/lib/python2.7/site-packages/alembic/util/pyfiles.py", line 93, in load_python_file
    module = load_module_py(module_id, path)
  File "/home/tkralidi/work/foss4g/GeoHealthCheck/local/lib/python2.7/site-packages/alembic/util/compat.py", line 75, in load_module_py
    mod = imp.load_source(module_id, path, fp)
  File "migrations/env.py", line 87, in <module>
    run_migrations_online()
  File "migrations/env.py", line 80, in run_migrations_online
    context.run_migrations()
  File "<string>", line 8, in run_migrations
  File "/home/tkralidi/work/foss4g/GeoHealthCheck/local/lib/python2.7/site-packages/alembic/runtime/environment.py", line 836, in run_migrations
    self.get_context().run_migrations(**kw)
  File "/home/tkralidi/work/foss4g/GeoHealthCheck/local/lib/python2.7/site-packages/alembic/runtime/migration.py", line 321, in run_migrations
    for step in self._migrations_fn(heads, self):
  File "/home/tkralidi/work/foss4g/GeoHealthCheck/local/lib/python2.7/site-packages/alembic/command.py", line 156, in retrieve_migrations
    revision_context.run_autogenerate(rev, context)
  File "/home/tkralidi/work/foss4g/GeoHealthCheck/local/lib/python2.7/site-packages/alembic/autogenerate/api.py", line 415, in run_autogenerate
    self._run_environment(rev, migration_context, True)
  File "/home/tkralidi/work/foss4g/GeoHealthCheck/local/lib/python2.7/site-packages/alembic/autogenerate/api.py", line 427, in _run_environment
    raise util.CommandError("Target database is not up to date.")
alembic.util.exc.CommandError: Target database is not up to date.
```