### PR TITLE
resource authentication

### DIFF
--- a/GeoHealthCheck/plugins/probe/http.py
+++ b/GeoHealthCheck/plugins/probe/http.py
@@ -38,6 +38,7 @@ class HttpGet(Probe):
     }
     """Param defs"""
 
+
 class HttpGetQuery(HttpGet):
     """
     Do HTTP GET Request, to poll/ping any Resource bare url with query string.

--- a/GeoHealthCheck/plugins/probe/http.py
+++ b/GeoHealthCheck/plugins/probe/http.py
@@ -1,3 +1,4 @@
+from GeoHealthCheck.plugin import Plugin
 from GeoHealthCheck.probe import Probe
 
 
@@ -21,6 +22,21 @@ class HttpGet(Probe):
     }
     """Checks avail"""
 
+    PARAM_DEFS = {
+        'username': {
+            'type': 'string',
+            'description': 'HTTP-Basic-Authentication username',
+            'default': None,
+            'required': False
+        },
+        'password': {
+            'type': 'string',
+            'description': 'HTTP-Basic-Authentication password',
+            'default': None,
+            'required': False
+        }
+    }
+    """Param defs"""
 
 class HttpGetQuery(HttpGet):
     """
@@ -34,14 +50,14 @@ class HttpGetQuery(HttpGet):
         """
     REQUEST_TEMPLATE = '?{query}'
 
-    PARAM_DEFS = {
+    PARAM_DEFS = Plugin.merge(HttpGet.PARAM_DEFS, {
         'query': {
             'type': 'string',
             'description': 'The query string to add to request (without ?)',
             'default': None,
             'required': True
         }
-    }
+    })
     """Param defs"""
 
 
@@ -61,7 +77,7 @@ class HttpPost(HttpGet):
     REQUEST_HEADERS = {'content-type': '{post_content_type}'}
     REQUEST_TEMPLATE = '{body}'
 
-    PARAM_DEFS = {
+    PARAM_DEFS = Plugin.merge(HttpGet.PARAM_DEFS, {
         'body': {
             'type': 'string',
             'description': 'The post body to send',
@@ -74,7 +90,7 @@ class HttpPost(HttpGet):
             'default': 'text/xml;charset=UTF-8',
             'required': True
         }
-    }
+    })
     """Param defs"""
 
     def get_request_headers(self):

--- a/GeoHealthCheck/plugins/probe/owsgetcaps.py
+++ b/GeoHealthCheck/plugins/probe/owsgetcaps.py
@@ -1,4 +1,5 @@
 from GeoHealthCheck.plugin import Plugin
+from GeoHealthCheck.plugins.probe.http import HttpGet
 from GeoHealthCheck.probe import Probe
 
 
@@ -18,7 +19,7 @@ class OwsGetCaps(Probe):
     REQUEST_TEMPLATE = \
         '?SERVICE={service}&VERSION={version}&REQUEST=GetCapabilities'
 
-    PARAM_DEFS = {
+    PARAM_DEFS = Plugin.merge(HttpGet.PARAM_DEFS, {
         'service': {
             'type': 'string',
             'description': 'The OWS service within resource endpoint',
@@ -32,7 +33,7 @@ class OwsGetCaps(Probe):
             'required': True,
             'range': None
         }
-    }
+    })
     """Param defs, to be specified in subclasses"""
 
     CHECKS_AVAIL = {

--- a/GeoHealthCheck/plugins/probe/sta.py
+++ b/GeoHealthCheck/plugins/probe/sta.py
@@ -1,4 +1,6 @@
 from GeoHealthCheck.probe import Probe
+from GeoHealthCheck.plugin import Plugin
+from GeoHealthCheck.plugins.probe.http import HttpGet
 
 
 class StaCaps(Probe):
@@ -12,6 +14,9 @@ class StaCaps(Probe):
 
     def __init__(self):
         Probe.__init__(self)
+
+    PARAM_DEFS = Plugin.merge(HttpGet.PARAM_DEFS, {})
+    """Param defs"""
 
     CHECKS_AVAIL = {
         'GeoHealthCheck.plugins.check.checks.HttpStatusNoError': {
@@ -53,7 +58,7 @@ class StaGetEntities(Probe):
     def __init__(self):
         Probe.__init__(self)
 
-    PARAM_DEFS = {
+    PARAM_DEFS = Plugin.merge(StaCaps.PARAM_DEFS, {
         'entities': {
             'type': 'string',
             'description': 'The STA Entity collection type',
@@ -63,7 +68,7 @@ class StaGetEntities(Probe):
                       'Locations', 'Sensors', 'FeaturesOfInterest',
                       'ObservedProperties', 'HistoricalLocations']
         }
-    }
+    })
     """Param defs"""
 
     CHECKS_AVAIL = {

--- a/GeoHealthCheck/plugins/probe/tms.py
+++ b/GeoHealthCheck/plugins/probe/tms.py
@@ -1,5 +1,6 @@
 from GeoHealthCheck.probe import Probe
 from GeoHealthCheck.plugin import Plugin
+from GeoHealthCheck.plugins.probe.http import HttpGet
 from owslib.tms import TileMapService
 
 
@@ -14,6 +15,9 @@ class TmsCaps(Probe):
 
     def __init__(self):
         Probe.__init__(self)
+
+    PARAM_DEFS = Plugin.merge(HttpGet.PARAM_DEFS, {})
+    """Param defs"""
 
     CHECKS_AVAIL = {
         'GeoHealthCheck.plugins.check.checks.XmlParse': {
@@ -50,7 +54,7 @@ class TmsGetTile(Probe):
     # brtachtergrondkaart/1/0/0.png
     REQUEST_TEMPLATE = '/{layer}/{zoom}/{x}/{y}.{extension}'
 
-    PARAM_DEFS = {
+    PARAM_DEFS = Plugin.merge(TmsCaps.PARAM_DEFS, {
         'layer': {
             'type': 'string',
             'description': 'The TMS Layer within resource endpoint',
@@ -86,7 +90,7 @@ class TmsGetTile(Probe):
             'required': True,
             'range': None
         }
-    }
+    })
     """Param defs"""
 
     CHECKS_AVAIL = {

--- a/GeoHealthCheck/plugins/probe/wfs.py
+++ b/GeoHealthCheck/plugins/probe/wfs.py
@@ -1,5 +1,6 @@
 from GeoHealthCheck.probe import Probe
 from GeoHealthCheck.plugin import Plugin
+from GeoHealthCheck.plugins.probe.http import HttpGet
 from GeoHealthCheck.util import transform_bbox
 from owslib.wfs import WebFeatureService
 
@@ -40,7 +41,8 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   </wfs:Query>
 </wfs:GetFeature>
     """
-    PARAM_DEFS = {
+    
+    PARAM_DEFS = Plugin.merge(HttpGet.PARAM_DEFS, {
         'type_name': {
             'type': 'string',
             'description': 'The WFS FeatureType name',
@@ -84,7 +86,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             'required': True,
             'range': None
         }
-    }
+    })
     """Param defs"""
 
     CHECKS_AVAIL = {

--- a/GeoHealthCheck/plugins/probe/wfs.py
+++ b/GeoHealthCheck/plugins/probe/wfs.py
@@ -41,7 +41,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   </wfs:Query>
 </wfs:GetFeature>
     """
-    
+
     PARAM_DEFS = Plugin.merge(HttpGet.PARAM_DEFS, {
         'type_name': {
             'type': 'string',

--- a/GeoHealthCheck/plugins/probe/wms.py
+++ b/GeoHealthCheck/plugins/probe/wms.py
@@ -1,5 +1,6 @@
 from GeoHealthCheck.probe import Probe
 from GeoHealthCheck.plugin import Plugin
+from GeoHealthCheck.plugins.probe.http import HttpGet
 from owslib.wms import WebMapService
 
 
@@ -23,7 +24,7 @@ class WmsGetMapV1(Probe):
                        'WIDTH={width}&HEIGHT={height}&FORMAT={format}' + \
                        '&STYLES={styles}&EXCEPTIONS={exceptions}'
 
-    PARAM_DEFS = {
+    PARAM_DEFS = Plugin.merge(HttpGet.PARAM_DEFS, {
         'layers': {
             'type': 'stringlist',
             'description': 'The WMS Layer, select one',
@@ -78,7 +79,7 @@ class WmsGetMapV1(Probe):
             'range': None
         }
 
-    }
+    })
     """Param defs"""
 
     CHECKS_AVAIL = {

--- a/GeoHealthCheck/plugins/probe/wmsdrilldown.py
+++ b/GeoHealthCheck/plugins/probe/wmsdrilldown.py
@@ -1,6 +1,8 @@
 import random
 
 from GeoHealthCheck.probe import Probe
+from GeoHealthCheck.plugin import Plugin
+from GeoHealthCheck.plugins.probe.http import HttpGet
 from GeoHealthCheck.result import Result
 from owslib.wms import WebMapService
 
@@ -20,7 +22,7 @@ class WmsDrilldown(Probe):
 
     REQUEST_METHOD = 'GET'
 
-    PARAM_DEFS = {
+    PARAM_DEFS = Plugin.merge(HttpGet.PARAM_DEFS, {
         'drilldown_level': {
             'type': 'string',
             'description': 'How heavy the drilldown should be.',
@@ -28,7 +30,7 @@ class WmsDrilldown(Probe):
             'required': True,
             'range': ['minor', 'moderate', 'full']
         }
-    }
+    })
     """Param defs"""
 
     def __init__(self):

--- a/GeoHealthCheck/probe.py
+++ b/GeoHealthCheck/probe.py
@@ -231,7 +231,8 @@ class Probe(Plugin):
         headers = dict()
 
         if self._parameters['username'] and self._parameters['password']:
-            b64Val = base64.b64encode("%s:%s" % (self._parameters['username'], self._parameters['password']))
+            b64Val = base64.b64encode("%s:%s" % 
+                (self._parameters['username'], self._parameters['password']))
             headers.update({'Authorization': 'Basic %s' % b64Val})
 
         headers.update(self.REQUEST_HEADERS)

--- a/GeoHealthCheck/probe.py
+++ b/GeoHealthCheck/probe.py
@@ -231,7 +231,8 @@ class Probe(Plugin):
         headers = dict()
 
         if self._parameters['username'] and self._parameters['password']:
-            b64Val = base64.b64encode("%s:%s" % 
+            b64Val = base64.b64encode(
+                "%s:%s" %
                 (self._parameters['username'], self._parameters['password']))
             headers.update({'Authorization': 'Basic %s' % b64Val})
 

--- a/GeoHealthCheck/probe.py
+++ b/GeoHealthCheck/probe.py
@@ -230,10 +230,8 @@ class Probe(Plugin):
     def get_request_headers(self):
         headers = dict()
 
-        if self._parameters['username'] and self._parameters['password']:
-            b64Val = base64.b64encode(
-                "%s:%s" %
-                (self._parameters['username'], self._parameters['password']))
+        if 'username' in self._parameters and 'password' in self._parameters:
+            b64Val = base64.b64encode("%s:%s" % (self._parameters['username'], self._parameters['password']))
             headers.update({'Authorization': 'Basic %s' % b64Val})
 
         headers.update(self.REQUEST_HEADERS)

--- a/GeoHealthCheck/probe.py
+++ b/GeoHealthCheck/probe.py
@@ -2,6 +2,7 @@ import sys
 import datetime
 import logging
 import requests
+import base64
 from plugin import Plugin
 from init import App
 
@@ -227,7 +228,14 @@ class Probe(Plugin):
         pass
 
     def get_request_headers(self):
-        return self.REQUEST_HEADERS
+        headers = dict()
+
+        if self._parameters['username'] and self._parameters['password']:
+            b64Val = base64.b64encode("%s:%s" % (self._parameters['username'], self._parameters['password']))
+            headers.update({'Authorization': 'Basic %s' % b64Val})
+
+        headers.update(self.REQUEST_HEADERS)
+        return headers
 
     def perform_request(self):
         """ Perform actual request to service"""


### PR DESCRIPTION
HTTP Basic username/password implementation (issue #9). Credentials are stored per-probe, not üer-ressource. This allows to test the ressource and proper function of the security middleware at the same time.