### PR TITLE
Use sqlalchemy outerjoin for compability reasons

### DIFF
--- a/GeoHealthCheck/models.py
+++ b/GeoHealthCheck/models.py
@@ -273,9 +273,8 @@ class Recipient(DB.Model):
     def burry_dead(cls):
         RN = ResourceNotification
         q = DB.session.query(cls)\
-                      .join(RN,
-                            RN.recipient_id == cls.id,
-                            isouter=True)\
+                      .outerjoin(RN,
+                            RN.recipient_id == cls.id)\
                       .filter(RN.recipient_id.is_(None))
         for item in q:
             DB.session.delete(item)


### PR DESCRIPTION
Just a suggestion: allow use of older sqlalchemy versions by using `outerjoin()` instead of `join(.., isouter=True)`. In some environments python modules may have to be used from the distro, so packages may be slightly out-of-date. I recognized the requirements.txt, but for now this fix allows me to keep on running this software.