### PR TITLE
Fix connecting SMTP on localhost only

### DIFF
--- a/GeoHealthCheck/notifications.py
+++ b/GeoHealthCheck/notifications.py
@@ -102,8 +102,6 @@ def do_email(config, resource, run, status_changed, result):
     try:
         if config['GHC_SMTP']['tls']:
             server.starttls()
-        else:
-            server.connect()
     except Exception, err:
         LOGGER.exception("Cannot connect to smtp: %s[:%s]: %s",
                          config['GHC_SMTP']['server'],


### PR DESCRIPTION
Fix connecting _localhost_ by calling `connect()` on an already initialized smtplib object, introduced in 5ef60b331bf5495e557b6c1c48e5fad5893edeb7. [According to the docs](https://docs.python.org/2/library/smtplib.html#smtplib.SMTP.connect), `smtplib.SMTP()` calls the `connect` method for the given host. Calling `connect` again but without any parameters will fall back to smtplibs default, which is localhost:25.