### PR TITLE
Adding table-layout: fixed; to solve a layout problem

### DIFF
--- a/GeoHealthCheck/templates/edit_resource.html
+++ b/GeoHealthCheck/templates/edit_resource.html
@@ -5,7 +5,7 @@
     <h1 class="page-header">[{{ _('Edit') }}] <span id="resource_title_h1">{{ resource.title }}</span></h1>
 
     <div class="table-responsive">
-        <table class="table">
+        <table class="table" style="table-layout: fixed;">
             <tr>
                 <th>{{ _('Type') }}</th>
                 <td>{{ resource_types[resource.resource_type]['label'] }}</td>


### PR DESCRIPTION
Solving #204, I added a style setting and it's displaying correctly. Instead of : 
![screenshot_20180528_135049](https://user-images.githubusercontent.com/17755977/40625914-371b5b78-6283-11e8-91af-db50bde0e62c.png)

it displays:
![screenshot_20180528_142802](https://user-images.githubusercontent.com/17755977/40625945-78a1be8e-6283-11e8-8513-957a0aa6fd72.png)
