### PR TITLE
Include info about needing python dev to build

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -38,9 +38,10 @@ Install
   a ``virtualenv`` is self-contained and provides the flexibility to install /
   tear down / whatever packages without affecting system wide packages or
   settings.
+  If installing on Ubuntu, you may need to install the python-dev package for installation to complete successfully.
   
 - Download a GeoHealthCheck release from
-  https://github.com/geopython/GeoHealthCheck/releases, or clone manually from GitHub. You will need to have the python dev libraries for your operating system.
+  https://github.com/geopython/GeoHealthCheck/releases, or clone manually from GitHub. 
 
 .. code-block:: bash
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -34,13 +34,13 @@ Install
 
 .. note::
 
-  it is strongly recommended to install in a Python ``virtualenv``.
+  It is strongly recommended to install GeoHealthCheck in a Python ``virtualenv``.
   a ``virtualenv`` is self-contained and provides the flexibility to install /
   tear down / whatever packages without affecting system wide packages or
   settings.
-
+  
 - Download a GeoHealthCheck release from
-  https://github.com/geopython/GeoHealthCheck/releases, or clone manually from GitHub.
+  https://github.com/geopython/GeoHealthCheck/releases, or clone manually from GitHub. You will need to have the python dev libraries for your operating system.
 
 .. code-block:: bash
 


### PR DESCRIPTION
This might need slight rewriting but we need to include python-dev as a requirement or the paver setup bit fails