### PR TITLE
send notification mails to all TO addresses

### DIFF
--- a/GeoHealthCheck/notifications.py
+++ b/GeoHealthCheck/notifications.py
@@ -117,7 +117,7 @@ def do_email(config, resource, run, status_changed, result):
                          exc_info=err)
     try:
         server.sendmail(config['GHC_ADMIN_EMAIL'],
-                        config['GHC_NOTIFICATIONS_EMAIL'],
+                        notifications_email,
                         msg.as_string())
     except Exception as err:
         LOGGER.exception(str(err), exc_info=err)


### PR DESCRIPTION
SMTP.sendmail() sends mails only to the addresses passed in the to_address
parameter and ignores the header[1]. So we have to pass all addresses.
This also doesn't crash any longer if GHC_NOTIFICATIONS_EMAIL is not set

[1] https://docs.python.org/3/library/smtplib.html#smtplib.SMTP.sendmail