### PR TITLE
Issue #257 scheduled GHC status summary email reporting

### DIFF
--- a/GeoHealthCheck/app.py
+++ b/GeoHealthCheck/app.py
@@ -986,6 +986,29 @@ def reset(token=None):
 # REST Interface Calls
 #
 
+@APP.route('/api/v1.0/summary/')
+def api_summary(resource_type=None, resource_id=None):
+    """
+    Get health summary for all Resources within this instance.
+    """
+
+    health_summary = views.get_health_summary()
+
+    # Convert Runs to dict-like structure
+    for run in ['first_run', 'last_run']:
+        run_obj = health_summary.get(run, None)
+        if run_obj:
+            health_summary[run] = run_obj.for_json()
+
+    # Convert Resources failing to dict-like structure
+    failed_resources = []
+    for resource in health_summary['failed_resources']:
+        failed_resources.append(resource.for_json())
+    health_summary['failed_resources'] = failed_resources
+
+    return jsonify(health_summary)
+
+
 @APP.route('/api/v1.0/probes-avail/')
 @APP.route('/api/v1.0/probes-avail/<resource_type>')
 @APP.route('/api/v1.0/probes-avail/<resource_type>/<int:resource_id>')

--- a/GeoHealthCheck/config_main.py
+++ b/GeoHealthCheck/config_main.py
@@ -108,6 +108,7 @@ GHC_PLUGINS = [
     'GeoHealthCheck.plugins.probe.wmsdrilldown',
     'GeoHealthCheck.plugins.probe.wfs3',
     'GeoHealthCheck.plugins.probe.esrifs',
+    'GeoHealthCheck.plugins.probe.ghcreport',
 
     # Checkers
     'GeoHealthCheck.plugins.check.checks',
@@ -168,5 +169,9 @@ GHC_PROBE_DEFAULTS = {
     },
     'OSGeo:GeoNode': {
         'probe_class': None
+    },
+    'GHC:Report': {
+        'probe_class':
+            'GeoHealthCheck.plugins.probe.ghcreport.GHCEmailReporter'
     }
 }

--- a/GeoHealthCheck/enums.py
+++ b/GeoHealthCheck/enums.py
@@ -88,5 +88,8 @@ RESOURCE_TYPES = {
     },
     'OSGeo:GeoNode': {
         'label': 'GeoNode instance'
+    },
+    'GHC:Report': {
+        'label': 'GeoHealthCheck Reporter (GHC-R)'
     }
 }

--- a/GeoHealthCheck/healthcheck.py
+++ b/GeoHealthCheck/healthcheck.py
@@ -159,6 +159,7 @@ def sniff_test_resource(config, resource_type, url):
                          'OGC:STA': [urlopen],
                          'WWW:LINK': [urlopen],
                          'FTP': [urlopen],
+                         'GHC:Report': [urlopen],
                          'OSGeo:GeoNode': [geonode_get_ows],
                          }
     try:

--- a/GeoHealthCheck/models.py
+++ b/GeoHealthCheck/models.py
@@ -109,6 +109,14 @@ class Run(DB.Model):
     def __repr__(self):
         return '<Run %r>' % (self.identifier)
 
+    def for_json(self):
+        return {
+            'success': self.success,
+            'response_time': self.response_time,
+            'checked_datetime': self.checked_datetime,
+            'message': self.message
+        }
+
 
 class ProbeVars(DB.Model):
     """
@@ -579,6 +587,19 @@ class Resource(DB.Model):
         self.auth_obj = ResourceAuth.create(self.auth)
 
         return self.auth_obj.add_auth_header(headers_dict)
+
+    def for_json(self):
+        return {
+            'identifier': self.identifier,
+            'resource_type': self.resource_type,
+            'url': self.url,
+            'title': self.title,
+            'active': self.active,
+            'owner': self.owner.username,
+            'owner_identifier': self.owner.identifier,
+            'run_frequency': self.run_frequency,
+            'reliability': round(self.reliability, 1)
+        }
 
 
 class ResourceLock(DB.Model):

--- a/GeoHealthCheck/plugins/probe/ghcreport.py
+++ b/GeoHealthCheck/plugins/probe/ghcreport.py
@@ -1,0 +1,110 @@
+import logging
+from email.mime.text import MIMEText
+from email.utils import formataddr
+
+from flask_babel import gettext
+
+from GeoHealthCheck.init import App
+from GeoHealthCheck.probe import Probe
+from GeoHealthCheck.result import Result
+from GeoHealthCheck.util import render_template2, send_email
+
+LOGGER = logging.getLogger(__name__)
+
+
+class GHCEmailReporter(Probe):
+    """
+    Probe for GeoHealthCheck endpoint recurring status Reporter.
+    When invoked it will get the overall status of the GHC Endpoint and email
+    a summary, with links to more detailed reports.
+    """
+
+    NAME = 'GHC Email Reporter'
+
+    DESCRIPTION = 'Fetches Resources status summary ' \
+                  'from GHC endpoint and reports by email'
+
+    RESOURCE_TYPE = 'GHC:Report'
+
+    REQUEST_METHOD = 'GET'
+
+    PARAM_DEFS = {}
+
+    """Param defs"""
+
+    def __init__(self):
+        Probe.__init__(self)
+
+    def perform_request(self):
+        """
+        Perform the reporting.
+        """
+
+        # Be sure to use bare root URL http://.../FeatureServer
+        ghc_url = self._resource.url.split('?')[0]
+
+        # Assemble request templates with root FS URL
+        req_tpl = {
+            'summary': ghc_url + '/api/v1.0/summary/',
+        }
+
+        # 1. Test top Service endpoint existence
+        result = Result(True, 'Get GHC Report')
+        result.start()
+        summary_report = 'Cannot get summary from %s' % \
+                         req_tpl['summary']
+        try:
+            summary_report = self.perform_get_request(
+                req_tpl['summary']).json()
+        except Exception as err:
+            result.set(False, str(err))
+
+        result.stop()
+        self.result.add_result(result)
+
+        # ASSERTION: will do email reporting from here
+
+        # 3. Test getting Features from Layers
+        result = Result(True, 'Send Email')
+        result.start()
+
+        try:
+            config = App.get_config()
+
+            # Create message body with report
+            template_vars = {
+                'summary': summary_report,
+                'config': config
+            }
+
+            msg_body = render_template2(
+                'status_report_email.txt', template_vars)
+            resource = self._resource
+
+            to_addrs = resource.get_recipients('email')
+            if len(to_addrs) == 0:
+                raise Exception(
+                    "No emails set for resource %s",
+                    resource.identifier)
+
+            msg = MIMEText(msg_body, 'plain', 'utf-8')
+            msg['From'] = formataddr((config['GHC_SITE_TITLE'],
+                                      config['GHC_ADMIN_EMAIL']))
+            msg['To'] = ', '.join(to_addrs)
+            msg['Subject'] = '[%s] %s' % (config['GHC_SITE_TITLE'],
+                                          gettext('Status summary'))
+
+            from_addr = '%s <%s>' % (config['GHC_SITE_TITLE'],
+                                     config['GHC_ADMIN_EMAIL'])
+
+            msg_text = msg.as_string()
+            send_email(config['GHC_SMTP'], from_addr, to_addrs, msg_text)
+        except Exception as err:
+            msg = 'Cannot send email. Contact admin: '
+            LOGGER.warning(msg + ' err=' + str(err))
+            result.set(False, 'Cannot send email: %s' % str(err))
+
+        result.stop()
+
+        # Add to overall Probe result
+        self.result.add_result(result)

--- a/GeoHealthCheck/plugins/probe/ghcreport.py
+++ b/GeoHealthCheck/plugins/probe/ghcreport.py
@@ -28,7 +28,15 @@ class GHCEmailReporter(Probe):
 
     REQUEST_METHOD = 'GET'
 
-    PARAM_DEFS = {}
+    PARAM_DEFS = {
+        'email': {
+            'type': 'string',
+            'description': 'A comma-separated list of email addresses \
+                           to send status report to',
+            'default': None,
+            'required': True
+        }
+    }
 
     """Param defs"""
 
@@ -77,14 +85,21 @@ class GHCEmailReporter(Probe):
 
             msg_body = render_template2(
                 'status_report_email.txt', template_vars)
-            resource = self._resource
 
-            to_addrs = resource.get_recipients('email')
-            if len(to_addrs) == 0:
+            resource = self._resource
+            to_addrs = self._parameters.get('email', None)
+            if to_addrs is None:
                 raise Exception(
-                    "No emails set for resource %s",
+                    'No emails set for GHCEmailReporter in resource=%s' %
                     resource.identifier)
 
+            to_addrs = to_addrs.replace(' ', '')
+            if len(to_addrs) == 0:
+                raise Exception(
+                    'No emails set for GHCEmailReporter in resource=%s' %
+                    resource.identifier)
+
+            to_addrs = to_addrs.split(',')
             msg = MIMEText(msg_body, 'plain', 'utf-8')
             msg['From'] = formataddr((config['GHC_SITE_TITLE'],
                                       config['GHC_ADMIN_EMAIL']))

--- a/GeoHealthCheck/plugins/probe/ghcreport.py
+++ b/GeoHealthCheck/plugins/probe/ghcreport.py
@@ -44,27 +44,25 @@ class GHCEmailReporter(Probe):
         ghc_url = self._resource.url.split('?')[0]
 
         # Assemble request templates with root FS URL
-        req_tpl = {
-            'summary': ghc_url + '/api/v1.0/summary/',
-        }
 
-        # 1. Test top Service endpoint existence
+        summary_url = ghc_url + '/api/v1.0/summary/'
+
+        # 1. Get the summary (JSON) report from GHC endpoint
         result = Result(True, 'Get GHC Report')
         result.start()
-        summary_report = 'Cannot get summary from %s' % \
-                         req_tpl['summary']
         try:
-            summary_report = self.perform_get_request(
-                req_tpl['summary']).json()
+            summary_report = self.perform_get_request(summary_url).json()
         except Exception as err:
-            result.set(False, str(err))
+            msg = 'Cannot get summary from %s err=%s' % \
+                  (summary_url, str(err))
+            result.set(False, msg)
+            result.stop()
+            self.result.add_result(result)
+            return
 
-        result.stop()
-        self.result.add_result(result)
+        # ASSERTION - summary report fetch ok
 
-        # ASSERTION: will do email reporting from here
-
-        # 3. Test getting Features from Layers
+        # 2. Do email reporting with summary report
         result = Result(True, 'Send Email')
         result.start()
 

--- a/GeoHealthCheck/templates/status_report_email.txt
+++ b/GeoHealthCheck/templates/status_report_email.txt
@@ -1,0 +1,24 @@
+{{ _('Hi: this is an automated message from the') }} {{ config.GHC_SITE_TITLE }} {{ _('service') }}.
+
+== {{ _('Monitoring Period') }} ==
+{{ _('From') }}: {{ summary.first_run.checked_datetime }}
+{{ _('To') }}: {{ summary.last_run.checked_datetime }}
+
+== {{ _('Status') }} ==
+{{ _('Resources') }}: {{ summary.total }}
+{{ _('Operational') }}: {{ summary.success.number }}
+{{ _('Failing') }}: {{ summary.fail.number }}
+{{ _('Reliability') }}: {{ summary.reliability }}%
+
+== {{ _('Failing') }} {{ _('Resources') }} ==
+{% for resource in summary.failed_resources %}
+[{{resource.identifier}}] - "{{resource.title}}"
+  {{ _('Reliability') }}: {{ resource.reliability }}%
+  {{ _('URL') }}: {{ resource.url }}
+  {{ _('owner') }}: {{ resource.owner }}
+  {{ _('Details') }}: {{ config.GHC_SITE_URL }}/resource/{{resource.identifier}}
+{% endfor %}
+
+== {{ _('Links') }} ==
+Home: {{ config.GHC_SITE_URL }}
+Status CSV: {{ config.GHC_SITE_URL }}/csv

--- a/GeoHealthCheck/templates/status_report_email.txt
+++ b/GeoHealthCheck/templates/status_report_email.txt
@@ -15,10 +15,12 @@
 [{{resource.identifier}}] - "{{resource.title}}"
   {{ _('Reliability') }}: {{ resource.reliability }}%
   {{ _('URL') }}: {{ resource.url }}
-  {{ _('owner') }}: {{ resource.owner }}
+  {{ _('Owner') }}: {{ resource.owner }}
   {{ _('Details') }}: {{ config.GHC_SITE_URL }}/resource/{{resource.identifier}}
 {% endfor %}
-
+{% if summary.failed_resources|length == 0 %}{{ _('None') }}!{% endif %}
 == {{ _('Links') }} ==
-Home: {{ config.GHC_SITE_URL }}
-Status CSV: {{ config.GHC_SITE_URL }}/csv
+{{ _('Home') }}: {{ config.GHC_SITE_URL }}
+{{ _('Summary') }} JSON: {{ config.GHC_SITE_URL }}/api/v1.0/summary
+{{ _('Summary') }} TXT: {{ config.GHC_SITE_URL }}/api/v1.0/summary.txt
+{{ _('Status') }}  CSV: {{ config.GHC_SITE_URL }}/csv

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ Features
 - extensible healthchecks via Plugins
 - per-resource scheduling and notifications
 - per-resource HTTP-authentication like Basic, Token (optional)
+- regular status summary report via email (optional)
 
 Links
 -----

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -107,6 +107,7 @@ The following Resource Types are available:
 - Web Address (URL)
 - File Transfer Protocol (FTP)
 - GeoNode autodiscovery (see :ref:`geonode_notes`)
+- GeoHealthCheck Reporter (GHC-R) (see :ref:`ghc_reporter_notes`)
 
 Next fill in the URL and optional tags for the Resource.
 
@@ -378,6 +379,38 @@ which is constructed with the template: *GeoNode _hostname_*, where *_hostname_*
 is a host name from url provided. For example, let's assume you add GeoNode
 instance that is served from `demo.geonode.org`. All resources created in this way
 will have *GeoNode demo.geonode.org* tag.
+
+.. _ghc_reporter_notes:
+
+GeoHealthCheck Reporter Type
+----------------------------
+
+The `GeoHealthCheck Reporter (GHC-R)` Resource type allows users to receive a regular status
+summary report by email for the Resources in any local or remote GHC instance.
+Typically this is used for the local GHC instance. To setup:
+
+* in top-menu select `Add | GeoHealthCheck Reporter (GHC-R)`
+* in `Add Resource` screen add the site URL of the target GHC instance
+
+Then in `Resource Edit` screen
+
+* set `Run Every` field to a high value, typically 1440 minutes (every 24 hour)
+* click `Edit` button for the assigned `GHC Email Reporter`
+* set `email` field in `Probe Parameters` to one or more email adresses (comma-separated)
+
+.. warning::
+	The Resource form-field *"Notify emails"* is **not** the target for the Email Report!
+	It is used to report any possible errors for report assembly and email delivery.
+
+.. warning::
+	Summary email reports may in cases be marked as spam by your email provider.
+	In those cases you should greenlist (mark as non-spam) the sender email address.
+
+.. note::
+	Tip: The `GeoHealthCheck Reporter Probe` uses
+	the `/api/v1.0/summary` API call. You can always get the last status report message as text via
+	the URL `<GHC Instance URL>/api/v1.0/summary.txt` for example
+	https://demo.geohealthcheck.org/api/v1.0/summary.txt
 
 Resource Authentication
 -----------------------


### PR DESCRIPTION
This implements a basic summary email reporting for `Resources` within a GHC instance as follows:

* a new API service `/api/v1.0/summary[.json]` gives a  summary report in JSON
* `/api/v1.0/summary.txt` gives formatted summary report message in text
* a new Resource Type `GHC:Report` with `GHCEmailReporter` `Probe` handles getting the summary report from API and sending email (to or more receivers configured in `Probe`).
* uses standard Jinja2 template for report formatting
* for upcoming GHC endpoint monitoring (see #247) an additional type `GHC:Monitor` may be developed 
* the reporting schedule uses regular Probe scheduling
* the Probe can be configured with one or more emails
* other Probes may be developed e.g. webhooks
* both local and remote GHC instances can be reported
* standard (Resource) error handling if reporting fails
* no database changes
* documentation added

This was the easiest and most flexible way to develop this feature. 
