### PR TITLE
#263 enable Basic Auth access to GHC plus fix reported URLs for #257

### DIFF
--- a/GeoHealthCheck/plugins/probe/ghcreport.py
+++ b/GeoHealthCheck/plugins/probe/ghcreport.py
@@ -59,7 +59,14 @@ class GHCEmailReporter(Probe):
         result = Result(True, 'Get GHC Report')
         result.start()
         try:
-            summary_report = self.perform_get_request(summary_url).json()
+            response = self.perform_get_request(summary_url)
+            status = response.status_code
+            overall_status = status / 100
+            if overall_status in [4, 5]:
+                raise Exception('HTTP Error status=%d reason=%s'
+                                % (status, response.reason))
+
+            summary_report = response.json()
         except Exception as err:
             msg = 'Cannot get summary from %s err=%s' % \
                   (summary_url, str(err))

--- a/GeoHealthCheck/templates/status_report_email.txt
+++ b/GeoHealthCheck/templates/status_report_email.txt
@@ -1,4 +1,5 @@
-{{ _('Hi: this is an automated message from the') }} {{ config.GHC_SITE_TITLE }} {{ _('service') }}.
+{{ _('Hi: this is a status report sent by the') }} "{{ config.GHC_SITE_TITLE }}" {{ _('service') }}
+{{ _('at') }} {{ config.GHC_SITE_URL }} {{ _('for the GeoHealthCheck endpoint at') }} {{ summary.site_url }}
 
 == {{ _('Monitoring Period') }} ==
 {{ _('From') }}: {{ summary.first_run.checked_datetime }}
@@ -16,11 +17,11 @@
   {{ _('Reliability') }}: {{ resource.reliability }}%
   {{ _('URL') }}: {{ resource.url }}
   {{ _('Owner') }}: {{ resource.owner }}
-  {{ _('Details') }}: {{ config.GHC_SITE_URL }}/resource/{{resource.identifier}}
+  {{ _('Details') }}: {{ summary.site_url }}/resource/{{resource.identifier}}
 {% endfor %}
 {% if summary.failed_resources|length == 0 %}{{ _('None') }}!{% endif %}
 == {{ _('Links') }} ==
-{{ _('Home') }}: {{ config.GHC_SITE_URL }}
-{{ _('Summary') }} JSON: {{ config.GHC_SITE_URL }}/api/v1.0/summary
-{{ _('Summary') }} TXT: {{ config.GHC_SITE_URL }}/api/v1.0/summary.txt
-{{ _('Status') }}  CSV: {{ config.GHC_SITE_URL }}/csv
+{{ _('Home') }}: {{ summary.site_url  }}
+{{ _('Summary') }} JSON: {{ summary.site_url }}/api/v1.0/summary
+{{ _('Summary') }} TXT: {{ summary.site_url }}/api/v1.0/summary.txt
+{{ _('Status') }}  CSV: {{ summary.site_url }}/csv

--- a/GeoHealthCheck/views.py
+++ b/GeoHealthCheck/views.py
@@ -33,6 +33,8 @@ import util
 from sqlalchemy import text
 from plugin import Plugin
 from factory import Factory
+from init import App
+APP = App.get_app()
 
 LOGGER = logging.getLogger(__name__)
 
@@ -156,6 +158,7 @@ def get_health_summary():
     success_percentage = 100 - failed_percentage
 
     response = {
+        'site_url': APP.config['GHC_SITE_URL'],
         'total': total_resources,
         'success': {
             'number': success,

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -30,7 +30,7 @@ Optionally override these settings for your instance in ``instance/config_site.p
 - **GHC_USER_PLUGINS**: list of Plugin classes or modules provided by user (you)
 - **GHC_PROBE_DEFAULTS**: Default `Probe` class to assign on "add" per Resource-type
 - **GHC_METADATA_CACHE_SECS**: metadata, "Capabilities Docs", cache expiry time, default 900 secs, -1 to disable
-- **GHC_REQUIRE_WEBAPP_AUTH**: require authentication (login) to access GHC webapp (default: ``False``)
+- **GHC_REQUIRE_WEBAPP_AUTH**: require authentication (login or Basic Auth) to access GHC webapp and APIs (default: ``False``)
 - **GHC_RUNNER_IN_WEBAPP**: should the GHC Runner Daemon be run in webapp (default: ``True``), more below
 - **GHC_LOG_LEVEL**: logging level: 10=DEBUG 20=INFO 30=WARN(ING) 40=ERROR 50=FATAL/CRITICAL (default: 30, WARNING)
 - **GHC_MAP**: default map settings
@@ -146,5 +146,6 @@ In some cases it is required that only logged-in (authenticated) users like the 
 access the entire GHC webapp and its APIs. In that case the config setting **GHC_REQUIRE_WEBAPP_AUTH**
 should be set to ``True``. (version 0.7+). Non-authenticated users will be presented with
 the login screen. Initially only the ``admin`` user will be able to login, but it is possible to register
-and allow additional users by registering within the ``admin`` login session.
-Note that password reset is still enabled.
+and allow additional users by registering these within the ``admin`` login session.
+Note that password reset is still enabled. For remote REST API calls standard HTTP Basic
+Authentication (via the HTTP `Authentication` request header) can be used.

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -394,6 +394,7 @@ Typically this is used for the local GHC instance. To setup:
 
 Then in `Resource Edit` screen
 
+* if the target GHC instance requires authentication: in `Authentication` form field select `Basic` and fill in username and password
 * set `Run Every` field to a high value, typically 1440 minutes (every 24 hour)
 * click `Edit` button for the assigned `GHC Email Reporter`
 * set `email` field in `Probe Parameters` to one or more email adresses (comma-separated)


### PR DESCRIPTION
Implements Basic Auth access in a clean way, using Flask-Login (was already used) [request_loader](https://flask-login.readthedocs.io/en/latest/#custom-login-using-request-loader) interceptor mechanism. May be a start for remote CRUD via GHC REST API.

Also added for #257 (Status Reporting)

* explicit failure report if Probe fails for Basic Auth (handle 400-500 range responses)
* fix URLs in report (referred to local GHC endpoint i.s.o. of report target GHC endpoint)