### PR TITLE
update all translation files plus doc HOWTO translations

### DIFF
--- a/GeoHealthCheck/translations/de/LC_MESSAGES/messages.po
+++ b/GeoHealthCheck/translations/de/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  GeoHealthCheck\n"
 "Report-Msgid-Bugs-To: https://github.com/geopython/GeoHealthCheck/issues\n"
-"POT-Creation-Date: 2019-06-17 14:17+0200\n"
+"POT-Creation-Date: 2019-07-19 16:20+0200\n"
 "PO-Revision-Date: 2015-10-26 07:29+0000\n"
 "Last-Translator: Hannes I. Reuter\n"
 "Language: de\n"
@@ -16,88 +16,88 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
-#: GeoHealthCheck/app.py:456
+#: GeoHealthCheck/app.py:490
 msgid "This site is not configured for self-registration"
 msgstr "Diese Webseite unterstützt keine Selbstregistrierung"
 
-#: GeoHealthCheck/app.py:457
+#: GeoHealthCheck/app.py:491
 msgid "Please contact"
 msgstr "Bitte kontaktiere"
 
-#: GeoHealthCheck/app.py:469
+#: GeoHealthCheck/app.py:503
 msgid "Invalid username or email"
 msgstr "Ungültiger Benutzername oder E-Mail"
 
-#: GeoHealthCheck/app.py:482
+#: GeoHealthCheck/app.py:516
 msgid "already registered"
 msgstr "schon registriert"
 
-#: GeoHealthCheck/app.py:505
+#: GeoHealthCheck/app.py:539
 msgid "No resources detected"
 msgstr "Keine Ressourcen vorhanden"
 
-#: GeoHealthCheck/app.py:519
+#: GeoHealthCheck/app.py:553
 msgid "Service already registered"
 msgstr "Der Service ist bereits registriert"
 
-#: GeoHealthCheck/app.py:591
+#: GeoHealthCheck/app.py:625
 msgid "Services registered"
 msgstr "Der Service wurde registriert"
 
-#: GeoHealthCheck/app.py:711 GeoHealthCheck/app.py:740
-#: GeoHealthCheck/app.py:767
+#: GeoHealthCheck/app.py:747 GeoHealthCheck/app.py:776
+#: GeoHealthCheck/app.py:804
 msgid "Resource not found"
 msgstr "Ressource wurde nicht gefunden"
 
-#: GeoHealthCheck/app.py:720
+#: GeoHealthCheck/app.py:756
 msgid "INFO"
 msgstr "INFO"
 
-#: GeoHealthCheck/app.py:723 GeoHealthCheck/templates/edit_resource.html:361
+#: GeoHealthCheck/app.py:759 GeoHealthCheck/templates/edit_resource.html:440
 msgid "ERROR"
 msgstr "FEHLER"
 
-#: GeoHealthCheck/app.py:726
+#: GeoHealthCheck/app.py:762
 msgid "Resource tested successfully"
 msgstr "Ressource wurde erfolgreich getestet"
 
-#: GeoHealthCheck/app.py:761
+#: GeoHealthCheck/app.py:798
 msgid "You do not have access to delete this resource"
 msgstr "Du hast keine Rechte um die Ressource zu löschen"
 
-#: GeoHealthCheck/app.py:775
+#: GeoHealthCheck/app.py:812
 msgid "Resource deleted"
 msgstr "Ressource gelöscht"
 
-#: GeoHealthCheck/app.py:859
+#: GeoHealthCheck/app.py:896
 msgid "Invalid username and / or password"
 msgstr "Ungültiger Benutzer bzw. Passwort"
 
-#: GeoHealthCheck/app.py:874
+#: GeoHealthCheck/app.py:911
 msgid "Logged out"
 msgstr "Ausgelogged"
 
-#: GeoHealthCheck/app.py:895
+#: GeoHealthCheck/app.py:932
 msgid "Invalid email"
 msgstr "Ungültige E-Mail"
 
-#: GeoHealthCheck/app.py:916
+#: GeoHealthCheck/app.py:953
 msgid "reset password"
 msgstr "Passwort zurücksetzen"
 
-#: GeoHealthCheck/app.py:931
+#: GeoHealthCheck/app.py:968
 msgid "Password reset link sent via email"
 msgstr "Link zum Zurücksetzen des Passworts wurde per E-Mail verschickt"
 
-#: GeoHealthCheck/app.py:953
+#: GeoHealthCheck/app.py:990
 msgid "Invalid token"
 msgstr "Unültiger Token"
 
-#: GeoHealthCheck/app.py:963
+#: GeoHealthCheck/app.py:1000
 msgid "Password required"
 msgstr "Passwort benötigt"
 
-#: GeoHealthCheck/app.py:970
+#: GeoHealthCheck/app.py:1007
 msgid "Update password OK"
 msgstr "Passwort aktualisieren OK"
 
@@ -105,11 +105,13 @@ msgstr "Passwort aktualisieren OK"
 msgid "Invalid resource type"
 msgstr "Ungültiger Ressourcetyp"
 
-#: GeoHealthCheck/healthcheck.py:214 GeoHealthCheck/healthcheck.py:242
+#: GeoHealthCheck/healthcheck.py:216 GeoHealthCheck/healthcheck.py:246
 msgid "for"
 msgstr "für"
 
 #: GeoHealthCheck/notifications.py:239
+#: GeoHealthCheck/templates/status_report_email.txt:11
+#: GeoHealthCheck/templates/status_report_email.txt:14
 msgid "Failing"
 msgstr "Fehler"
 
@@ -124,6 +126,10 @@ msgstr "Immer noch fehlerhaft"
 #: GeoHealthCheck/notifications.py:245 GeoHealthCheck/notifications.py:247
 msgid "Passing"
 msgstr "Jetzt geht's"
+
+#: GeoHealthCheck/plugins/probe/ghcreport.py:115
+msgid "Status summary"
+msgstr ""
 
 #: GeoHealthCheck/templates/add.html:5
 msgid "Add Resource"
@@ -171,86 +177,98 @@ msgid "Active"
 msgstr "Aktiv"
 
 #: GeoHealthCheck/templates/edit_resource.html:23
+msgid "Authentication"
+msgstr ""
+
+#: GeoHealthCheck/templates/edit_resource.html:26
+msgid "Select optional authentication method and applicable credentials"
+msgstr ""
+
+#: GeoHealthCheck/templates/edit_resource.html:67
 msgid "Notify emails"
 msgstr "Benachrichtigungs-E-Mails"
 
-#: GeoHealthCheck/templates/edit_resource.html:25
+#: GeoHealthCheck/templates/edit_resource.html:69
 msgid "You can enter multiple emails separated with comma"
 msgstr "Mehrere E-Mail-Adressen können kommasepariert angegeben werden"
 
-#: GeoHealthCheck/templates/edit_resource.html:31
+#: GeoHealthCheck/templates/edit_resource.html:75
 msgid "Notify webhooks"
 msgstr "Benachrichtigungs-Webhooks"
 
-#: GeoHealthCheck/templates/edit_resource.html:44
+#: GeoHealthCheck/templates/edit_resource.html:88
 msgid "Enter url for webhook."
 msgstr "Bitte URL für Webhook eingeben"
 
-#: GeoHealthCheck/templates/edit_resource.html:45
+#: GeoHealthCheck/templates/edit_resource.html:89
 msgid "Optionally, enter payload as list of key=value lines or JSON object."
 msgstr ""
 "Optional: geben Sie die Last als liste von key=value Zeilen or als JSON-"
 "Objekt an."
 
-#: GeoHealthCheck/templates/edit_resource.html:66
+#: GeoHealthCheck/templates/edit_resource.html:110
 #: GeoHealthCheck/templates/resource.html:62
+#: GeoHealthCheck/templates/status_report_email.txt:19
 msgid "Owner"
 msgstr "Eigentümer"
 
-#: GeoHealthCheck/templates/edit_resource.html:71
+#: GeoHealthCheck/templates/edit_resource.html:115
 #: GeoHealthCheck/templates/includes/resources_list.html:5
 #: GeoHealthCheck/templates/resource.html:67
 msgid "Name"
 msgstr "Name"
 
-#: GeoHealthCheck/templates/edit_resource.html:92
+#: GeoHealthCheck/templates/edit_resource.html:136
 #: GeoHealthCheck/templates/resource.html:86
 msgid "Run Every"
 msgstr "Ausführung alle..."
 
-#: GeoHealthCheck/templates/edit_resource.html:94
+#: GeoHealthCheck/templates/edit_resource.html:138
 #: GeoHealthCheck/templates/resource.html:88
 msgid "minutes"
 msgstr "Minuten"
 
-#: GeoHealthCheck/templates/edit_resource.html:120
+#: GeoHealthCheck/templates/edit_resource.html:164
 #: GeoHealthCheck/templates/includes/resources_list.html:6
+#: GeoHealthCheck/templates/status_report_email.txt:8
+#: GeoHealthCheck/templates/status_report_email.txt:27
 msgid "Status"
 msgstr "Status"
 
-#: GeoHealthCheck/templates/edit_resource.html:124
+#: GeoHealthCheck/templates/edit_resource.html:168
 #: GeoHealthCheck/templates/includes/resources_list.html:29
 #: GeoHealthCheck/templates/includes/resources_list.html:38
 #: GeoHealthCheck/templates/notification_email.txt:10
 #: GeoHealthCheck/templates/notification_email.txt:16
+#: GeoHealthCheck/templates/status_report_email.txt:20
 msgid "Details"
 msgstr "Details"
 
-#: GeoHealthCheck/templates/edit_resource.html:134
-#: GeoHealthCheck/templates/edit_resource.html:340
-#: GeoHealthCheck/templates/edit_resource.html:357
+#: GeoHealthCheck/templates/edit_resource.html:178
+#: GeoHealthCheck/templates/edit_resource.html:418
+#: GeoHealthCheck/templates/edit_resource.html:436
 msgid "Save"
 msgstr "Speichern"
 
-#: GeoHealthCheck/templates/edit_resource.html:135
-#: GeoHealthCheck/templates/edit_resource.html:370
-#: GeoHealthCheck/templates/edit_resource.html:378
-#: GeoHealthCheck/templates/edit_resource.html:385
+#: GeoHealthCheck/templates/edit_resource.html:179
+#: GeoHealthCheck/templates/edit_resource.html:449
+#: GeoHealthCheck/templates/edit_resource.html:457
+#: GeoHealthCheck/templates/edit_resource.html:464
 msgid "Test"
 msgstr "Test"
 
-#: GeoHealthCheck/templates/edit_resource.html:136
+#: GeoHealthCheck/templates/edit_resource.html:180
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: GeoHealthCheck/templates/edit_resource.html:137
+#: GeoHealthCheck/templates/edit_resource.html:181
 #: GeoHealthCheck/templates/includes/check_edit_form.html:12
 #: GeoHealthCheck/templates/includes/probe_edit_form.html:126
 #: GeoHealthCheck/templates/resource.html:47
 msgid "Delete"
 msgstr "Löschen"
 
-#: GeoHealthCheck/templates/edit_resource.html:405
+#: GeoHealthCheck/templates/edit_resource.html:484
 #: GeoHealthCheck/templates/resource.html:191
 msgid "Delete resource"
 msgstr "Eintrag löschen"
@@ -264,6 +282,7 @@ msgid "Failing Resources"
 msgstr "Fehlerhafte Ressourcen"
 
 #: GeoHealthCheck/templates/home.html:23
+#: GeoHealthCheck/templates/status_report_email.txt:22
 msgid "None"
 msgstr "Keine"
 
@@ -291,40 +310,44 @@ msgid "Resource Types"
 msgstr "Ressourcentypen"
 
 #: GeoHealthCheck/templates/layout.html:84
-#: GeoHealthCheck/templates/layout.html:99
+#: GeoHealthCheck/templates/layout.html:102
 msgid "Show All"
 msgstr "Alle anzeigen"
 
-#: GeoHealthCheck/templates/layout.html:90
+#: GeoHealthCheck/templates/layout.html:86
+msgid "Show Mine"
+msgstr ""
+
+#: GeoHealthCheck/templates/layout.html:93
 msgid "Tags"
 msgstr "Tags"
 
-#: GeoHealthCheck/templates/layout.html:105
+#: GeoHealthCheck/templates/layout.html:108
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: GeoHealthCheck/templates/layout.html:107
+#: GeoHealthCheck/templates/layout.html:110
 #: GeoHealthCheck/templates/resource.html:149
 msgid "History"
 msgstr "Vergangenheit"
 
-#: GeoHealthCheck/templates/layout.html:107
+#: GeoHealthCheck/templates/layout.html:110
 msgid "days"
 msgstr "Tage"
 
-#: GeoHealthCheck/templates/layout.html:108
+#: GeoHealthCheck/templates/layout.html:111
 msgid "Runner in Webapp"
 msgstr ""
 
-#: GeoHealthCheck/templates/layout.html:109
+#: GeoHealthCheck/templates/layout.html:112
 msgid "Probe Timeout"
 msgstr "Timeout der Untersuchung"
 
-#: GeoHealthCheck/templates/layout.html:110
+#: GeoHealthCheck/templates/layout.html:113
 msgid "Minimal Run Freq"
 msgstr "Minimale Durchlauffrequenz"
 
-#: GeoHealthCheck/templates/layout.html:131
+#: GeoHealthCheck/templates/layout.html:134
 #: GeoHealthCheck/templates/opensearch_description.xml:11
 msgid "Powered by"
 msgstr "Unterstützt durch"
@@ -365,6 +388,7 @@ msgstr "Hallo: Das ist eine automatisierte Nachricht von"
 
 #: GeoHealthCheck/templates/notification_email.txt:4
 #: GeoHealthCheck/templates/reset_password_email.txt:1
+#: GeoHealthCheck/templates/status_report_email.txt:1
 msgid "service"
 msgstr "Service"
 
@@ -457,6 +481,8 @@ msgstr "Max"
 
 #: GeoHealthCheck/templates/includes/resources_list.html:7
 #: GeoHealthCheck/templates/resource.html:112
+#: GeoHealthCheck/templates/status_report_email.txt:12
+#: GeoHealthCheck/templates/status_report_email.txt:17
 msgid "Reliability"
 msgstr "Verlässlichkeit"
 
@@ -512,6 +538,8 @@ msgid "Download"
 msgstr "Download"
 
 #: GeoHealthCheck/templates/resources.html:15
+#: GeoHealthCheck/templates/status_report_email.txt:9
+#: GeoHealthCheck/templates/status_report_email.txt:14
 msgid "Resources"
 msgstr "Ressource"
 
@@ -523,17 +551,56 @@ msgstr "Suche..."
 msgid "results"
 msgstr "Ergebnisse"
 
-#: GeoHealthCheck/templates/includes/overall_status.html:1
-msgid "Dashboard"
-msgstr "Dashboard"
+#: GeoHealthCheck/templates/status_report_email.txt:1
+msgid "Hi: this is a status report sent by the"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:2
+msgid "at"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:2
+msgid "for the GeoHealthCheck endpoint at"
+msgstr ""
 
 #: GeoHealthCheck/templates/includes/overall_status.html:3
+#: GeoHealthCheck/templates/status_report_email.txt:4
 msgid "Monitoring Period"
 msgstr "Überwachungs-Zeitraum"
 
+#: GeoHealthCheck/templates/status_report_email.txt:5
+msgid "From"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:6
+msgid "To"
+msgstr ""
+
 #: GeoHealthCheck/templates/includes/overall_status.html:20
+#: GeoHealthCheck/templates/status_report_email.txt:10
 msgid "Operational"
 msgstr "Operationel"
+
+#: GeoHealthCheck/templates/status_report_email.txt:18
+msgid "URL"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:23
+msgid "Links"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:24
+msgid "Home"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:25
+#: GeoHealthCheck/templates/status_report_email.txt:26
+msgid "Summary"
+msgstr ""
+
+#: GeoHealthCheck/templates/includes/overall_status.html:1
+msgid "Dashboard"
+msgstr "Dashboard"
 
 #: GeoHealthCheck/templates/includes/overall_status.html:40
 msgid "Reliable"

--- a/GeoHealthCheck/translations/de_DE/LC_MESSAGES/messages.po
+++ b/GeoHealthCheck/translations/de_DE/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  GeoHealthCheck\n"
 "Report-Msgid-Bugs-To: https://github.com/geopython/GeoHealthCheck/issues\n"
-"POT-Creation-Date: 2019-06-17 14:17+0200\n"
+"POT-Creation-Date: 2019-07-19 16:20+0200\n"
 "PO-Revision-Date: 2015-10-26 07:26+0000\n"
 "Last-Translator: Hannes I. Reuter\n"
 "Language: de_DE\n"
@@ -17,88 +17,88 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
-#: GeoHealthCheck/app.py:456
+#: GeoHealthCheck/app.py:490
 msgid "This site is not configured for self-registration"
 msgstr "Diese Webseite unterstützt keine Selbstregistrierung"
 
-#: GeoHealthCheck/app.py:457
+#: GeoHealthCheck/app.py:491
 msgid "Please contact"
 msgstr "Bitte kontaktiere"
 
-#: GeoHealthCheck/app.py:469
+#: GeoHealthCheck/app.py:503
 msgid "Invalid username or email"
 msgstr ""
 
-#: GeoHealthCheck/app.py:482
+#: GeoHealthCheck/app.py:516
 msgid "already registered"
 msgstr "schon registriert"
 
-#: GeoHealthCheck/app.py:505
+#: GeoHealthCheck/app.py:539
 msgid "No resources detected"
 msgstr ""
 
-#: GeoHealthCheck/app.py:519
+#: GeoHealthCheck/app.py:553
 msgid "Service already registered"
 msgstr "Der Service ist schon registriert"
 
-#: GeoHealthCheck/app.py:591
+#: GeoHealthCheck/app.py:625
 msgid "Services registered"
 msgstr ""
 
-#: GeoHealthCheck/app.py:711 GeoHealthCheck/app.py:740
-#: GeoHealthCheck/app.py:767
+#: GeoHealthCheck/app.py:747 GeoHealthCheck/app.py:776
+#: GeoHealthCheck/app.py:804
 msgid "Resource not found"
 msgstr "Ressource wurde nicht gefunden"
 
-#: GeoHealthCheck/app.py:720
+#: GeoHealthCheck/app.py:756
 msgid "INFO"
 msgstr ""
 
-#: GeoHealthCheck/app.py:723 GeoHealthCheck/templates/edit_resource.html:361
+#: GeoHealthCheck/app.py:759 GeoHealthCheck/templates/edit_resource.html:440
 msgid "ERROR"
 msgstr "FEHLER"
 
-#: GeoHealthCheck/app.py:726
+#: GeoHealthCheck/app.py:762
 msgid "Resource tested successfully"
 msgstr "Ressource wurde erfolgreich getestet"
 
-#: GeoHealthCheck/app.py:761
+#: GeoHealthCheck/app.py:798
 msgid "You do not have access to delete this resource"
 msgstr "Du hast keine Rechte um die Ressource zu löschen"
 
-#: GeoHealthCheck/app.py:775
+#: GeoHealthCheck/app.py:812
 msgid "Resource deleted"
 msgstr "Ressource gelöscht"
 
-#: GeoHealthCheck/app.py:859
+#: GeoHealthCheck/app.py:896
 msgid "Invalid username and / or password"
 msgstr "Ungültiger Benutzer bzw. Passwort"
 
-#: GeoHealthCheck/app.py:874
+#: GeoHealthCheck/app.py:911
 msgid "Logged out"
 msgstr "Ausgelogged"
 
-#: GeoHealthCheck/app.py:895
+#: GeoHealthCheck/app.py:932
 msgid "Invalid email"
 msgstr ""
 
-#: GeoHealthCheck/app.py:916
+#: GeoHealthCheck/app.py:953
 msgid "reset password"
 msgstr ""
 
-#: GeoHealthCheck/app.py:931
+#: GeoHealthCheck/app.py:968
 msgid "Password reset link sent via email"
 msgstr ""
 
-#: GeoHealthCheck/app.py:953
+#: GeoHealthCheck/app.py:990
 msgid "Invalid token"
 msgstr ""
 
-#: GeoHealthCheck/app.py:963
+#: GeoHealthCheck/app.py:1000
 msgid "Password required"
 msgstr ""
 
-#: GeoHealthCheck/app.py:970
+#: GeoHealthCheck/app.py:1007
 msgid "Update password OK"
 msgstr ""
 
@@ -106,11 +106,13 @@ msgstr ""
 msgid "Invalid resource type"
 msgstr "Ungültiger Ressourcetyp"
 
-#: GeoHealthCheck/healthcheck.py:214 GeoHealthCheck/healthcheck.py:242
+#: GeoHealthCheck/healthcheck.py:216 GeoHealthCheck/healthcheck.py:246
 msgid "for"
 msgstr "für"
 
 #: GeoHealthCheck/notifications.py:239
+#: GeoHealthCheck/templates/status_report_email.txt:11
+#: GeoHealthCheck/templates/status_report_email.txt:14
 msgid "Failing"
 msgstr "Fehler"
 
@@ -125,6 +127,10 @@ msgstr "Immer noch fehlerhaft"
 #: GeoHealthCheck/notifications.py:245 GeoHealthCheck/notifications.py:247
 msgid "Passing"
 msgstr "Jetzt geht's"
+
+#: GeoHealthCheck/plugins/probe/ghcreport.py:115
+msgid "Status summary"
+msgstr ""
 
 #: GeoHealthCheck/templates/add.html:5
 msgid "Add Resource"
@@ -172,84 +178,96 @@ msgid "Active"
 msgstr ""
 
 #: GeoHealthCheck/templates/edit_resource.html:23
+msgid "Authentication"
+msgstr ""
+
+#: GeoHealthCheck/templates/edit_resource.html:26
+msgid "Select optional authentication method and applicable credentials"
+msgstr ""
+
+#: GeoHealthCheck/templates/edit_resource.html:67
 msgid "Notify emails"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:25
+#: GeoHealthCheck/templates/edit_resource.html:69
 msgid "You can enter multiple emails separated with comma"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:31
+#: GeoHealthCheck/templates/edit_resource.html:75
 msgid "Notify webhooks"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:44
+#: GeoHealthCheck/templates/edit_resource.html:88
 msgid "Enter url for webhook."
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:45
+#: GeoHealthCheck/templates/edit_resource.html:89
 msgid "Optionally, enter payload as list of key=value lines or JSON object."
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:66
+#: GeoHealthCheck/templates/edit_resource.html:110
 #: GeoHealthCheck/templates/resource.html:62
+#: GeoHealthCheck/templates/status_report_email.txt:19
 msgid "Owner"
 msgstr "Eigentümer"
 
-#: GeoHealthCheck/templates/edit_resource.html:71
+#: GeoHealthCheck/templates/edit_resource.html:115
 #: GeoHealthCheck/templates/includes/resources_list.html:5
 #: GeoHealthCheck/templates/resource.html:67
 msgid "Name"
 msgstr "Name"
 
-#: GeoHealthCheck/templates/edit_resource.html:92
+#: GeoHealthCheck/templates/edit_resource.html:136
 #: GeoHealthCheck/templates/resource.html:86
 msgid "Run Every"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:94
+#: GeoHealthCheck/templates/edit_resource.html:138
 #: GeoHealthCheck/templates/resource.html:88
 msgid "minutes"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:120
+#: GeoHealthCheck/templates/edit_resource.html:164
 #: GeoHealthCheck/templates/includes/resources_list.html:6
+#: GeoHealthCheck/templates/status_report_email.txt:8
+#: GeoHealthCheck/templates/status_report_email.txt:27
 msgid "Status"
 msgstr "Status"
 
-#: GeoHealthCheck/templates/edit_resource.html:124
+#: GeoHealthCheck/templates/edit_resource.html:168
 #: GeoHealthCheck/templates/includes/resources_list.html:29
 #: GeoHealthCheck/templates/includes/resources_list.html:38
 #: GeoHealthCheck/templates/notification_email.txt:10
 #: GeoHealthCheck/templates/notification_email.txt:16
+#: GeoHealthCheck/templates/status_report_email.txt:20
 msgid "Details"
 msgstr "Details"
 
-#: GeoHealthCheck/templates/edit_resource.html:134
-#: GeoHealthCheck/templates/edit_resource.html:340
-#: GeoHealthCheck/templates/edit_resource.html:357
+#: GeoHealthCheck/templates/edit_resource.html:178
+#: GeoHealthCheck/templates/edit_resource.html:418
+#: GeoHealthCheck/templates/edit_resource.html:436
 msgid "Save"
 msgstr "Speichern"
 
-#: GeoHealthCheck/templates/edit_resource.html:135
-#: GeoHealthCheck/templates/edit_resource.html:370
-#: GeoHealthCheck/templates/edit_resource.html:378
-#: GeoHealthCheck/templates/edit_resource.html:385
+#: GeoHealthCheck/templates/edit_resource.html:179
+#: GeoHealthCheck/templates/edit_resource.html:449
+#: GeoHealthCheck/templates/edit_resource.html:457
+#: GeoHealthCheck/templates/edit_resource.html:464
 msgid "Test"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:136
+#: GeoHealthCheck/templates/edit_resource.html:180
 msgid "Cancel"
 msgstr "Abbruch"
 
-#: GeoHealthCheck/templates/edit_resource.html:137
+#: GeoHealthCheck/templates/edit_resource.html:181
 #: GeoHealthCheck/templates/includes/check_edit_form.html:12
 #: GeoHealthCheck/templates/includes/probe_edit_form.html:126
 #: GeoHealthCheck/templates/resource.html:47
 msgid "Delete"
 msgstr "Löschen"
 
-#: GeoHealthCheck/templates/edit_resource.html:405
+#: GeoHealthCheck/templates/edit_resource.html:484
 #: GeoHealthCheck/templates/resource.html:191
 msgid "Delete resource"
 msgstr "Eintrag löschen"
@@ -263,6 +281,7 @@ msgid "Failing Resources"
 msgstr ""
 
 #: GeoHealthCheck/templates/home.html:23
+#: GeoHealthCheck/templates/status_report_email.txt:22
 msgid "None"
 msgstr ""
 
@@ -290,40 +309,44 @@ msgid "Resource Types"
 msgstr "Ressourcentypen"
 
 #: GeoHealthCheck/templates/layout.html:84
-#: GeoHealthCheck/templates/layout.html:99
+#: GeoHealthCheck/templates/layout.html:102
 msgid "Show All"
 msgstr ""
 
-#: GeoHealthCheck/templates/layout.html:90
+#: GeoHealthCheck/templates/layout.html:86
+msgid "Show Mine"
+msgstr ""
+
+#: GeoHealthCheck/templates/layout.html:93
 msgid "Tags"
 msgstr ""
 
-#: GeoHealthCheck/templates/layout.html:105
+#: GeoHealthCheck/templates/layout.html:108
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: GeoHealthCheck/templates/layout.html:107
+#: GeoHealthCheck/templates/layout.html:110
 #: GeoHealthCheck/templates/resource.html:149
 msgid "History"
 msgstr "Vergangenheit"
 
-#: GeoHealthCheck/templates/layout.html:107
+#: GeoHealthCheck/templates/layout.html:110
 msgid "days"
 msgstr "tage"
 
-#: GeoHealthCheck/templates/layout.html:108
+#: GeoHealthCheck/templates/layout.html:111
 msgid "Runner in Webapp"
 msgstr ""
 
-#: GeoHealthCheck/templates/layout.html:109
+#: GeoHealthCheck/templates/layout.html:112
 msgid "Probe Timeout"
 msgstr ""
 
-#: GeoHealthCheck/templates/layout.html:110
+#: GeoHealthCheck/templates/layout.html:113
 msgid "Minimal Run Freq"
 msgstr ""
 
-#: GeoHealthCheck/templates/layout.html:131
+#: GeoHealthCheck/templates/layout.html:134
 #: GeoHealthCheck/templates/opensearch_description.xml:11
 msgid "Powered by"
 msgstr "Angetrieben durch"
@@ -364,6 +387,7 @@ msgstr "Hallo: Das ist eine automatisierte Nachricht von"
 
 #: GeoHealthCheck/templates/notification_email.txt:4
 #: GeoHealthCheck/templates/reset_password_email.txt:1
+#: GeoHealthCheck/templates/status_report_email.txt:1
 msgid "service"
 msgstr "service"
 
@@ -454,6 +478,8 @@ msgstr "Max"
 
 #: GeoHealthCheck/templates/includes/resources_list.html:7
 #: GeoHealthCheck/templates/resource.html:112
+#: GeoHealthCheck/templates/status_report_email.txt:12
+#: GeoHealthCheck/templates/status_report_email.txt:17
 msgid "Reliability"
 msgstr "Verlässlichkeit"
 
@@ -507,6 +533,8 @@ msgid "Download"
 msgstr ""
 
 #: GeoHealthCheck/templates/resources.html:15
+#: GeoHealthCheck/templates/status_report_email.txt:9
+#: GeoHealthCheck/templates/status_report_email.txt:14
 msgid "Resources"
 msgstr "Ressource"
 
@@ -518,17 +546,56 @@ msgstr "Suche..."
 msgid "results"
 msgstr "Ergebnisse"
 
-#: GeoHealthCheck/templates/includes/overall_status.html:1
-msgid "Dashboard"
-msgstr "Dashboard"
+#: GeoHealthCheck/templates/status_report_email.txt:1
+msgid "Hi: this is a status report sent by the"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:2
+msgid "at"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:2
+msgid "for the GeoHealthCheck endpoint at"
+msgstr ""
 
 #: GeoHealthCheck/templates/includes/overall_status.html:3
+#: GeoHealthCheck/templates/status_report_email.txt:4
 msgid "Monitoring Period"
 msgstr "Überwachungs-Zeitraum"
 
+#: GeoHealthCheck/templates/status_report_email.txt:5
+msgid "From"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:6
+msgid "To"
+msgstr ""
+
 #: GeoHealthCheck/templates/includes/overall_status.html:20
+#: GeoHealthCheck/templates/status_report_email.txt:10
 msgid "Operational"
 msgstr "Operationel"
+
+#: GeoHealthCheck/templates/status_report_email.txt:18
+msgid "URL"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:23
+msgid "Links"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:24
+msgid "Home"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:25
+#: GeoHealthCheck/templates/status_report_email.txt:26
+msgid "Summary"
+msgstr ""
+
+#: GeoHealthCheck/templates/includes/overall_status.html:1
+msgid "Dashboard"
+msgstr "Dashboard"
 
 #: GeoHealthCheck/templates/includes/overall_status.html:40
 msgid "Reliable"

--- a/GeoHealthCheck/translations/en/LC_MESSAGES/messages.po
+++ b/GeoHealthCheck/translations/en/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-06-17 14:17+0200\n"
+"POT-Creation-Date: 2019-07-19 16:20+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -19,88 +19,88 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
-#: GeoHealthCheck/app.py:456
+#: GeoHealthCheck/app.py:490
 msgid "This site is not configured for self-registration"
 msgstr ""
 
-#: GeoHealthCheck/app.py:457
+#: GeoHealthCheck/app.py:491
 msgid "Please contact"
 msgstr ""
 
-#: GeoHealthCheck/app.py:469
+#: GeoHealthCheck/app.py:503
 msgid "Invalid username or email"
 msgstr ""
 
-#: GeoHealthCheck/app.py:482
+#: GeoHealthCheck/app.py:516
 msgid "already registered"
 msgstr ""
 
-#: GeoHealthCheck/app.py:505
+#: GeoHealthCheck/app.py:539
 msgid "No resources detected"
 msgstr ""
 
-#: GeoHealthCheck/app.py:519
+#: GeoHealthCheck/app.py:553
 msgid "Service already registered"
 msgstr ""
 
-#: GeoHealthCheck/app.py:591
+#: GeoHealthCheck/app.py:625
 msgid "Services registered"
 msgstr ""
 
-#: GeoHealthCheck/app.py:711 GeoHealthCheck/app.py:740
-#: GeoHealthCheck/app.py:767
+#: GeoHealthCheck/app.py:747 GeoHealthCheck/app.py:776
+#: GeoHealthCheck/app.py:804
 msgid "Resource not found"
 msgstr ""
 
-#: GeoHealthCheck/app.py:720
+#: GeoHealthCheck/app.py:756
 msgid "INFO"
 msgstr ""
 
-#: GeoHealthCheck/app.py:723 GeoHealthCheck/templates/edit_resource.html:361
+#: GeoHealthCheck/app.py:759 GeoHealthCheck/templates/edit_resource.html:440
 msgid "ERROR"
 msgstr ""
 
-#: GeoHealthCheck/app.py:726
+#: GeoHealthCheck/app.py:762
 msgid "Resource tested successfully"
 msgstr ""
 
-#: GeoHealthCheck/app.py:761
+#: GeoHealthCheck/app.py:798
 msgid "You do not have access to delete this resource"
 msgstr ""
 
-#: GeoHealthCheck/app.py:775
+#: GeoHealthCheck/app.py:812
 msgid "Resource deleted"
 msgstr ""
 
-#: GeoHealthCheck/app.py:859
+#: GeoHealthCheck/app.py:896
 msgid "Invalid username and / or password"
 msgstr ""
 
-#: GeoHealthCheck/app.py:874
+#: GeoHealthCheck/app.py:911
 msgid "Logged out"
 msgstr ""
 
-#: GeoHealthCheck/app.py:895
+#: GeoHealthCheck/app.py:932
 msgid "Invalid email"
 msgstr ""
 
-#: GeoHealthCheck/app.py:916
+#: GeoHealthCheck/app.py:953
 msgid "reset password"
 msgstr ""
 
-#: GeoHealthCheck/app.py:931
+#: GeoHealthCheck/app.py:968
 msgid "Password reset link sent via email"
 msgstr ""
 
-#: GeoHealthCheck/app.py:953
+#: GeoHealthCheck/app.py:990
 msgid "Invalid token"
 msgstr ""
 
-#: GeoHealthCheck/app.py:963
+#: GeoHealthCheck/app.py:1000
 msgid "Password required"
 msgstr ""
 
-#: GeoHealthCheck/app.py:970
+#: GeoHealthCheck/app.py:1007
 msgid "Update password OK"
 msgstr ""
 
@@ -108,11 +108,13 @@ msgstr ""
 msgid "Invalid resource type"
 msgstr ""
 
-#: GeoHealthCheck/healthcheck.py:214 GeoHealthCheck/healthcheck.py:242
+#: GeoHealthCheck/healthcheck.py:216 GeoHealthCheck/healthcheck.py:246
 msgid "for"
 msgstr ""
 
 #: GeoHealthCheck/notifications.py:239
+#: GeoHealthCheck/templates/status_report_email.txt:11
+#: GeoHealthCheck/templates/status_report_email.txt:14
 msgid "Failing"
 msgstr ""
 
@@ -126,6 +128,10 @@ msgstr ""
 
 #: GeoHealthCheck/notifications.py:245 GeoHealthCheck/notifications.py:247
 msgid "Passing"
+msgstr ""
+
+#: GeoHealthCheck/plugins/probe/ghcreport.py:115
+msgid "Status summary"
 msgstr ""
 
 #: GeoHealthCheck/templates/add.html:5
@@ -168,6 +174,11 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
+#: GeoHealthCheck/templates/edit_resource.html:15
+#: GeoHealthCheck/templates/resource.html:58
+msgid "Active"
+msgstr ""
+
 #: GeoHealthCheck/templates/edit_resource.html:23
 msgid "Authentication"
 msgstr ""
@@ -176,90 +187,89 @@ msgstr ""
 msgid "Select optional authentication method and applicable credentials"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:15
-#: GeoHealthCheck/templates/resource.html:58
-msgid "Active"
-msgstr ""
-
-#: GeoHealthCheck/templates/edit_resource.html:25
+#: GeoHealthCheck/templates/edit_resource.html:67
 msgid "Notify emails"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:31
+#: GeoHealthCheck/templates/edit_resource.html:69
 msgid "You can enter multiple emails separated with comma"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:44
+#: GeoHealthCheck/templates/edit_resource.html:75
 msgid "Notify webhooks"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:45
+#: GeoHealthCheck/templates/edit_resource.html:88
 msgid "Enter url for webhook."
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:66
+#: GeoHealthCheck/templates/edit_resource.html:89
 msgid "Optionally, enter payload as list of key=value lines or JSON object."
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:71
+#: GeoHealthCheck/templates/edit_resource.html:110
 #: GeoHealthCheck/templates/resource.html:62
+#: GeoHealthCheck/templates/status_report_email.txt:19
 msgid "Owner"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:92
+#: GeoHealthCheck/templates/edit_resource.html:115
 #: GeoHealthCheck/templates/includes/resources_list.html:5
 #: GeoHealthCheck/templates/resource.html:67
 msgid "Name"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:94
+#: GeoHealthCheck/templates/edit_resource.html:136
 #: GeoHealthCheck/templates/resource.html:86
 msgid "Run Every"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:120
+#: GeoHealthCheck/templates/edit_resource.html:138
 #: GeoHealthCheck/templates/resource.html:88
 msgid "minutes"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:124
+#: GeoHealthCheck/templates/edit_resource.html:164
 #: GeoHealthCheck/templates/includes/resources_list.html:6
+#: GeoHealthCheck/templates/status_report_email.txt:8
+#: GeoHealthCheck/templates/status_report_email.txt:27
 msgid "Status"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:134
+#: GeoHealthCheck/templates/edit_resource.html:168
 #: GeoHealthCheck/templates/includes/resources_list.html:29
 #: GeoHealthCheck/templates/includes/resources_list.html:38
 #: GeoHealthCheck/templates/notification_email.txt:10
 #: GeoHealthCheck/templates/notification_email.txt:16
+#: GeoHealthCheck/templates/status_report_email.txt:20
 msgid "Details"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:135
-#: GeoHealthCheck/templates/edit_resource.html:340
-#: GeoHealthCheck/templates/edit_resource.html:357
+#: GeoHealthCheck/templates/edit_resource.html:178
+#: GeoHealthCheck/templates/edit_resource.html:418
+#: GeoHealthCheck/templates/edit_resource.html:436
 msgid "Save"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:136
-#: GeoHealthCheck/templates/edit_resource.html:370
-#: GeoHealthCheck/templates/edit_resource.html:378
-#: GeoHealthCheck/templates/edit_resource.html:385
+#: GeoHealthCheck/templates/edit_resource.html:179
+#: GeoHealthCheck/templates/edit_resource.html:449
+#: GeoHealthCheck/templates/edit_resource.html:457
+#: GeoHealthCheck/templates/edit_resource.html:464
 msgid "Test"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:137
+#: GeoHealthCheck/templates/edit_resource.html:180
 msgid "Cancel"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:137
+#: GeoHealthCheck/templates/edit_resource.html:181
 #: GeoHealthCheck/templates/includes/check_edit_form.html:12
 #: GeoHealthCheck/templates/includes/probe_edit_form.html:126
 #: GeoHealthCheck/templates/resource.html:47
 msgid "Delete"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:405
+#: GeoHealthCheck/templates/edit_resource.html:484
 #: GeoHealthCheck/templates/resource.html:191
 msgid "Delete resource"
 msgstr ""
@@ -273,6 +283,7 @@ msgid "Failing Resources"
 msgstr ""
 
 #: GeoHealthCheck/templates/home.html:23
+#: GeoHealthCheck/templates/status_report_email.txt:22
 msgid "None"
 msgstr ""
 
@@ -300,7 +311,7 @@ msgid "Resource Types"
 msgstr ""
 
 #: GeoHealthCheck/templates/layout.html:84
-#: GeoHealthCheck/templates/layout.html:99
+#: GeoHealthCheck/templates/layout.html:102
 msgid "Show All"
 msgstr ""
 
@@ -378,6 +389,7 @@ msgstr ""
 
 #: GeoHealthCheck/templates/notification_email.txt:4
 #: GeoHealthCheck/templates/reset_password_email.txt:1
+#: GeoHealthCheck/templates/status_report_email.txt:1
 msgid "service"
 msgstr ""
 
@@ -468,6 +480,8 @@ msgstr ""
 
 #: GeoHealthCheck/templates/includes/resources_list.html:7
 #: GeoHealthCheck/templates/resource.html:112
+#: GeoHealthCheck/templates/status_report_email.txt:12
+#: GeoHealthCheck/templates/status_report_email.txt:17
 msgid "Reliability"
 msgstr ""
 
@@ -521,6 +535,8 @@ msgid "Download"
 msgstr ""
 
 #: GeoHealthCheck/templates/resources.html:15
+#: GeoHealthCheck/templates/status_report_email.txt:9
+#: GeoHealthCheck/templates/status_report_email.txt:14
 msgid "Resources"
 msgstr ""
 
@@ -532,16 +548,55 @@ msgstr ""
 msgid "results"
 msgstr ""
 
-#: GeoHealthCheck/templates/includes/overall_status.html:1
-msgid "Dashboard"
+#: GeoHealthCheck/templates/status_report_email.txt:1
+msgid "Hi: this is a status report sent by the"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:2
+msgid "at"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:2
+msgid "for the GeoHealthCheck endpoint at"
 msgstr ""
 
 #: GeoHealthCheck/templates/includes/overall_status.html:3
+#: GeoHealthCheck/templates/status_report_email.txt:4
 msgid "Monitoring Period"
 msgstr ""
 
+#: GeoHealthCheck/templates/status_report_email.txt:5
+msgid "From"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:6
+msgid "To"
+msgstr ""
+
 #: GeoHealthCheck/templates/includes/overall_status.html:20
+#: GeoHealthCheck/templates/status_report_email.txt:10
 msgid "Operational"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:18
+msgid "URL"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:23
+msgid "Links"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:24
+msgid "Home"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:25
+#: GeoHealthCheck/templates/status_report_email.txt:26
+msgid "Summary"
+msgstr ""
+
+#: GeoHealthCheck/templates/includes/overall_status.html:1
+msgid "Dashboard"
 msgstr ""
 
 #: GeoHealthCheck/templates/includes/overall_status.html:40

--- a/GeoHealthCheck/translations/es_BO/LC_MESSAGES/messages.po
+++ b/GeoHealthCheck/translations/es_BO/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  GeoHealthCheck\n"
 "Report-Msgid-Bugs-To: https://github.com/geopython/GeoHealthCheck/issues\n"
-"POT-Creation-Date: 2019-06-17 14:17+0200\n"
+"POT-Creation-Date: 2019-07-19 16:20+0200\n"
 "PO-Revision-Date: 2016-06-13 19:01-0400\n"
 "Last-Translator: Alejo C. Marcelo\n"
 "Language: es_BO\n"
@@ -17,88 +17,88 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
-#: GeoHealthCheck/app.py:456
+#: GeoHealthCheck/app.py:490
 msgid "This site is not configured for self-registration"
 msgstr "Este sitio no está configurado para auto-registrarse"
 
-#: GeoHealthCheck/app.py:457
+#: GeoHealthCheck/app.py:491
 msgid "Please contact"
 msgstr "Por favor contactar"
 
-#: GeoHealthCheck/app.py:469
+#: GeoHealthCheck/app.py:503
 msgid "Invalid username or email"
 msgstr ""
 
-#: GeoHealthCheck/app.py:482
+#: GeoHealthCheck/app.py:516
 msgid "already registered"
 msgstr "ya registrado"
 
-#: GeoHealthCheck/app.py:505
+#: GeoHealthCheck/app.py:539
 msgid "No resources detected"
 msgstr ""
 
-#: GeoHealthCheck/app.py:519
+#: GeoHealthCheck/app.py:553
 msgid "Service already registered"
 msgstr "Servicio ya registrado"
 
-#: GeoHealthCheck/app.py:591
+#: GeoHealthCheck/app.py:625
 msgid "Services registered"
 msgstr ""
 
-#: GeoHealthCheck/app.py:711 GeoHealthCheck/app.py:740
-#: GeoHealthCheck/app.py:767
+#: GeoHealthCheck/app.py:747 GeoHealthCheck/app.py:776
+#: GeoHealthCheck/app.py:804
 msgid "Resource not found"
 msgstr "Recurso no encontrado"
 
-#: GeoHealthCheck/app.py:720
+#: GeoHealthCheck/app.py:756
 msgid "INFO"
 msgstr ""
 
-#: GeoHealthCheck/app.py:723 GeoHealthCheck/templates/edit_resource.html:361
+#: GeoHealthCheck/app.py:759 GeoHealthCheck/templates/edit_resource.html:440
 msgid "ERROR"
 msgstr "Error"
 
-#: GeoHealthCheck/app.py:726
+#: GeoHealthCheck/app.py:762
 msgid "Resource tested successfully"
 msgstr "Recurso probado con éxito"
 
-#: GeoHealthCheck/app.py:761
+#: GeoHealthCheck/app.py:798
 msgid "You do not have access to delete this resource"
 msgstr "Usted no tiene acceso para eliminar este recurso"
 
-#: GeoHealthCheck/app.py:775
+#: GeoHealthCheck/app.py:812
 msgid "Resource deleted"
 msgstr "Recurso eliminado"
 
-#: GeoHealthCheck/app.py:859
+#: GeoHealthCheck/app.py:896
 msgid "Invalid username and / or password"
 msgstr "Usuario y/o contraseña incorrecto"
 
-#: GeoHealthCheck/app.py:874
+#: GeoHealthCheck/app.py:911
 msgid "Logged out"
 msgstr "Desconectado"
 
-#: GeoHealthCheck/app.py:895
+#: GeoHealthCheck/app.py:932
 msgid "Invalid email"
 msgstr ""
 
-#: GeoHealthCheck/app.py:916
+#: GeoHealthCheck/app.py:953
 msgid "reset password"
 msgstr ""
 
-#: GeoHealthCheck/app.py:931
+#: GeoHealthCheck/app.py:968
 msgid "Password reset link sent via email"
 msgstr ""
 
-#: GeoHealthCheck/app.py:953
+#: GeoHealthCheck/app.py:990
 msgid "Invalid token"
 msgstr ""
 
-#: GeoHealthCheck/app.py:963
+#: GeoHealthCheck/app.py:1000
 msgid "Password required"
 msgstr ""
 
-#: GeoHealthCheck/app.py:970
+#: GeoHealthCheck/app.py:1007
 msgid "Update password OK"
 msgstr ""
 
@@ -106,11 +106,13 @@ msgstr ""
 msgid "Invalid resource type"
 msgstr "Tipo de recurso no válido"
 
-#: GeoHealthCheck/healthcheck.py:214 GeoHealthCheck/healthcheck.py:242
+#: GeoHealthCheck/healthcheck.py:216 GeoHealthCheck/healthcheck.py:246
 msgid "for"
 msgstr "para"
 
 #: GeoHealthCheck/notifications.py:239
+#: GeoHealthCheck/templates/status_report_email.txt:11
+#: GeoHealthCheck/templates/status_report_email.txt:14
 msgid "Failing"
 msgstr "Inactivo"
 
@@ -125,6 +127,10 @@ msgstr "Sigue inactivo"
 #: GeoHealthCheck/notifications.py:245 GeoHealthCheck/notifications.py:247
 msgid "Passing"
 msgstr "Activo"
+
+#: GeoHealthCheck/plugins/probe/ghcreport.py:115
+msgid "Status summary"
+msgstr ""
 
 #: GeoHealthCheck/templates/add.html:5
 msgid "Add Resource"
@@ -172,84 +178,96 @@ msgid "Active"
 msgstr ""
 
 #: GeoHealthCheck/templates/edit_resource.html:23
+msgid "Authentication"
+msgstr ""
+
+#: GeoHealthCheck/templates/edit_resource.html:26
+msgid "Select optional authentication method and applicable credentials"
+msgstr ""
+
+#: GeoHealthCheck/templates/edit_resource.html:67
 msgid "Notify emails"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:25
+#: GeoHealthCheck/templates/edit_resource.html:69
 msgid "You can enter multiple emails separated with comma"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:31
+#: GeoHealthCheck/templates/edit_resource.html:75
 msgid "Notify webhooks"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:44
+#: GeoHealthCheck/templates/edit_resource.html:88
 msgid "Enter url for webhook."
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:45
+#: GeoHealthCheck/templates/edit_resource.html:89
 msgid "Optionally, enter payload as list of key=value lines or JSON object."
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:66
+#: GeoHealthCheck/templates/edit_resource.html:110
 #: GeoHealthCheck/templates/resource.html:62
+#: GeoHealthCheck/templates/status_report_email.txt:19
 msgid "Owner"
 msgstr "Propietario"
 
-#: GeoHealthCheck/templates/edit_resource.html:71
+#: GeoHealthCheck/templates/edit_resource.html:115
 #: GeoHealthCheck/templates/includes/resources_list.html:5
 #: GeoHealthCheck/templates/resource.html:67
 msgid "Name"
 msgstr "Nombre"
 
-#: GeoHealthCheck/templates/edit_resource.html:92
+#: GeoHealthCheck/templates/edit_resource.html:136
 #: GeoHealthCheck/templates/resource.html:86
 msgid "Run Every"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:94
+#: GeoHealthCheck/templates/edit_resource.html:138
 #: GeoHealthCheck/templates/resource.html:88
 msgid "minutes"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:120
+#: GeoHealthCheck/templates/edit_resource.html:164
 #: GeoHealthCheck/templates/includes/resources_list.html:6
+#: GeoHealthCheck/templates/status_report_email.txt:8
+#: GeoHealthCheck/templates/status_report_email.txt:27
 msgid "Status"
 msgstr "Estado"
 
-#: GeoHealthCheck/templates/edit_resource.html:124
+#: GeoHealthCheck/templates/edit_resource.html:168
 #: GeoHealthCheck/templates/includes/resources_list.html:29
 #: GeoHealthCheck/templates/includes/resources_list.html:38
 #: GeoHealthCheck/templates/notification_email.txt:10
 #: GeoHealthCheck/templates/notification_email.txt:16
+#: GeoHealthCheck/templates/status_report_email.txt:20
 msgid "Details"
 msgstr "Detalles"
 
-#: GeoHealthCheck/templates/edit_resource.html:134
-#: GeoHealthCheck/templates/edit_resource.html:340
-#: GeoHealthCheck/templates/edit_resource.html:357
+#: GeoHealthCheck/templates/edit_resource.html:178
+#: GeoHealthCheck/templates/edit_resource.html:418
+#: GeoHealthCheck/templates/edit_resource.html:436
 msgid "Save"
 msgstr "Guardar"
 
-#: GeoHealthCheck/templates/edit_resource.html:135
-#: GeoHealthCheck/templates/edit_resource.html:370
-#: GeoHealthCheck/templates/edit_resource.html:378
-#: GeoHealthCheck/templates/edit_resource.html:385
+#: GeoHealthCheck/templates/edit_resource.html:179
+#: GeoHealthCheck/templates/edit_resource.html:449
+#: GeoHealthCheck/templates/edit_resource.html:457
+#: GeoHealthCheck/templates/edit_resource.html:464
 msgid "Test"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:136
+#: GeoHealthCheck/templates/edit_resource.html:180
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: GeoHealthCheck/templates/edit_resource.html:137
+#: GeoHealthCheck/templates/edit_resource.html:181
 #: GeoHealthCheck/templates/includes/check_edit_form.html:12
 #: GeoHealthCheck/templates/includes/probe_edit_form.html:126
 #: GeoHealthCheck/templates/resource.html:47
 msgid "Delete"
 msgstr "Borrar"
 
-#: GeoHealthCheck/templates/edit_resource.html:405
+#: GeoHealthCheck/templates/edit_resource.html:484
 #: GeoHealthCheck/templates/resource.html:191
 msgid "Delete resource"
 msgstr "Eliminar recurso"
@@ -263,6 +281,7 @@ msgid "Failing Resources"
 msgstr ""
 
 #: GeoHealthCheck/templates/home.html:23
+#: GeoHealthCheck/templates/status_report_email.txt:22
 msgid "None"
 msgstr ""
 
@@ -290,40 +309,44 @@ msgid "Resource Types"
 msgstr "Tipos de recurso"
 
 #: GeoHealthCheck/templates/layout.html:84
-#: GeoHealthCheck/templates/layout.html:99
+#: GeoHealthCheck/templates/layout.html:102
 msgid "Show All"
 msgstr "Mostrar todo"
 
-#: GeoHealthCheck/templates/layout.html:90
+#: GeoHealthCheck/templates/layout.html:86
+msgid "Show Mine"
+msgstr ""
+
+#: GeoHealthCheck/templates/layout.html:93
 msgid "Tags"
 msgstr ""
 
-#: GeoHealthCheck/templates/layout.html:105
+#: GeoHealthCheck/templates/layout.html:108
 msgid "Settings"
 msgstr "Configuración"
 
-#: GeoHealthCheck/templates/layout.html:107
+#: GeoHealthCheck/templates/layout.html:110
 #: GeoHealthCheck/templates/resource.html:149
 msgid "History"
 msgstr "Historial"
 
-#: GeoHealthCheck/templates/layout.html:107
+#: GeoHealthCheck/templates/layout.html:110
 msgid "days"
 msgstr "días"
 
-#: GeoHealthCheck/templates/layout.html:108
+#: GeoHealthCheck/templates/layout.html:111
 msgid "Runner in Webapp"
 msgstr ""
 
-#: GeoHealthCheck/templates/layout.html:109
+#: GeoHealthCheck/templates/layout.html:112
 msgid "Probe Timeout"
 msgstr ""
 
-#: GeoHealthCheck/templates/layout.html:110
+#: GeoHealthCheck/templates/layout.html:113
 msgid "Minimal Run Freq"
 msgstr ""
 
-#: GeoHealthCheck/templates/layout.html:131
+#: GeoHealthCheck/templates/layout.html:134
 #: GeoHealthCheck/templates/opensearch_description.xml:11
 msgid "Powered by"
 msgstr ""
@@ -364,6 +387,7 @@ msgstr "Hola: Este es un mensaje automatico desde"
 
 #: GeoHealthCheck/templates/notification_email.txt:4
 #: GeoHealthCheck/templates/reset_password_email.txt:1
+#: GeoHealthCheck/templates/status_report_email.txt:1
 msgid "service"
 msgstr "Servicio"
 
@@ -454,6 +478,8 @@ msgstr "Máx"
 
 #: GeoHealthCheck/templates/includes/resources_list.html:7
 #: GeoHealthCheck/templates/resource.html:112
+#: GeoHealthCheck/templates/status_report_email.txt:12
+#: GeoHealthCheck/templates/status_report_email.txt:17
 msgid "Reliability"
 msgstr "Fiabilidad"
 
@@ -507,6 +533,8 @@ msgid "Download"
 msgstr ""
 
 #: GeoHealthCheck/templates/resources.html:15
+#: GeoHealthCheck/templates/status_report_email.txt:9
+#: GeoHealthCheck/templates/status_report_email.txt:14
 msgid "Resources"
 msgstr "Recurso"
 
@@ -518,17 +546,56 @@ msgstr "Buscar..."
 msgid "results"
 msgstr "resultados"
 
-#: GeoHealthCheck/templates/includes/overall_status.html:1
-msgid "Dashboard"
-msgstr "Tablero de control"
+#: GeoHealthCheck/templates/status_report_email.txt:1
+msgid "Hi: this is a status report sent by the"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:2
+msgid "at"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:2
+msgid "for the GeoHealthCheck endpoint at"
+msgstr ""
 
 #: GeoHealthCheck/templates/includes/overall_status.html:3
+#: GeoHealthCheck/templates/status_report_email.txt:4
 msgid "Monitoring Period"
 msgstr "Periodo de monitoreo"
 
+#: GeoHealthCheck/templates/status_report_email.txt:5
+msgid "From"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:6
+msgid "To"
+msgstr ""
+
 #: GeoHealthCheck/templates/includes/overall_status.html:20
+#: GeoHealthCheck/templates/status_report_email.txt:10
 msgid "Operational"
 msgstr "Operacional"
+
+#: GeoHealthCheck/templates/status_report_email.txt:18
+msgid "URL"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:23
+msgid "Links"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:24
+msgid "Home"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:25
+#: GeoHealthCheck/templates/status_report_email.txt:26
+msgid "Summary"
+msgstr ""
+
+#: GeoHealthCheck/templates/includes/overall_status.html:1
+msgid "Dashboard"
+msgstr "Tablero de control"
 
 #: GeoHealthCheck/templates/includes/overall_status.html:40
 msgid "Reliable"

--- a/GeoHealthCheck/translations/fr/LC_MESSAGES/messages.po
+++ b/GeoHealthCheck/translations/fr/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  GeoHealthCheck\n"
 "Report-Msgid-Bugs-To: https://github.com/geopython/GeoHealthCheck/issues\n"
-"POT-Creation-Date: 2019-06-17 14:17+0200\n"
+"POT-Creation-Date: 2019-07-19 16:20+0200\n"
 "PO-Revision-Date: 2015-10-21 00:15+0000\n"
 "Last-Translator: Tom Kralidis <tomkralidis@gmail.com>\n"
 "Language: fr\n"
@@ -15,88 +15,88 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
-#: GeoHealthCheck/app.py:456
+#: GeoHealthCheck/app.py:490
 msgid "This site is not configured for self-registration"
 msgstr "Ce site n'est pas configuré pour l'auto-inscription"
 
-#: GeoHealthCheck/app.py:457
+#: GeoHealthCheck/app.py:491
 msgid "Please contact"
 msgstr "S'il-vous-plaît contactez"
 
-#: GeoHealthCheck/app.py:469
+#: GeoHealthCheck/app.py:503
 msgid "Invalid username or email"
 msgstr "Nom d'utilisateur ou courriel incorrect"
 
-#: GeoHealthCheck/app.py:482
+#: GeoHealthCheck/app.py:516
 msgid "already registered"
 msgstr "déjà inscrit"
 
-#: GeoHealthCheck/app.py:505
+#: GeoHealthCheck/app.py:539
 msgid "No resources detected"
 msgstr "Pas de ressources détectées"
 
-#: GeoHealthCheck/app.py:519
+#: GeoHealthCheck/app.py:553
 msgid "Service already registered"
 msgstr "Service déjà enregistré"
 
-#: GeoHealthCheck/app.py:591
+#: GeoHealthCheck/app.py:625
 msgid "Services registered"
 msgstr "Services enregistrés"
 
-#: GeoHealthCheck/app.py:711 GeoHealthCheck/app.py:740
-#: GeoHealthCheck/app.py:767
+#: GeoHealthCheck/app.py:747 GeoHealthCheck/app.py:776
+#: GeoHealthCheck/app.py:804
 msgid "Resource not found"
 msgstr "Ressource introuvable"
 
-#: GeoHealthCheck/app.py:720
+#: GeoHealthCheck/app.py:756
 msgid "INFO"
 msgstr "INFO"
 
-#: GeoHealthCheck/app.py:723 GeoHealthCheck/templates/edit_resource.html:361
+#: GeoHealthCheck/app.py:759 GeoHealthCheck/templates/edit_resource.html:440
 msgid "ERROR"
 msgstr "ERREUR"
 
-#: GeoHealthCheck/app.py:726
+#: GeoHealthCheck/app.py:762
 msgid "Resource tested successfully"
 msgstr "Ressources testées avec succès"
 
-#: GeoHealthCheck/app.py:761
+#: GeoHealthCheck/app.py:798
 msgid "You do not have access to delete this resource"
 msgstr "Vous ne pouvez pas supprimer cette ressource"
 
-#: GeoHealthCheck/app.py:775
+#: GeoHealthCheck/app.py:812
 msgid "Resource deleted"
 msgstr "Ressource supprimée"
 
-#: GeoHealthCheck/app.py:859
+#: GeoHealthCheck/app.py:896
 msgid "Invalid username and / or password"
 msgstr "Nom d'utilisateur et / ou mot de passe incorrect"
 
-#: GeoHealthCheck/app.py:874
+#: GeoHealthCheck/app.py:911
 msgid "Logged out"
 msgstr "Déconnecté"
 
-#: GeoHealthCheck/app.py:895
+#: GeoHealthCheck/app.py:932
 msgid "Invalid email"
 msgstr "Courriel invalide"
 
-#: GeoHealthCheck/app.py:916
+#: GeoHealthCheck/app.py:953
 msgid "reset password"
 msgstr ""
 
-#: GeoHealthCheck/app.py:931
+#: GeoHealthCheck/app.py:968
 msgid "Password reset link sent via email"
 msgstr ""
 
-#: GeoHealthCheck/app.py:953
+#: GeoHealthCheck/app.py:990
 msgid "Invalid token"
 msgstr ""
 
-#: GeoHealthCheck/app.py:963
+#: GeoHealthCheck/app.py:1000
 msgid "Password required"
 msgstr "Mot de passe requis"
 
-#: GeoHealthCheck/app.py:970
+#: GeoHealthCheck/app.py:1007
 msgid "Update password OK"
 msgstr "Mise à jour de mot de passe OK"
 
@@ -104,11 +104,13 @@ msgstr "Mise à jour de mot de passe OK"
 msgid "Invalid resource type"
 msgstr "Type de ressource non valide"
 
-#: GeoHealthCheck/healthcheck.py:214 GeoHealthCheck/healthcheck.py:242
+#: GeoHealthCheck/healthcheck.py:216 GeoHealthCheck/healthcheck.py:246
 msgid "for"
 msgstr "pour"
 
 #: GeoHealthCheck/notifications.py:239
+#: GeoHealthCheck/templates/status_report_email.txt:11
+#: GeoHealthCheck/templates/status_report_email.txt:14
 msgid "Failing"
 msgstr "Échec"
 
@@ -123,6 +125,10 @@ msgstr "Échec répété"
 #: GeoHealthCheck/notifications.py:245 GeoHealthCheck/notifications.py:247
 msgid "Passing"
 msgstr "Passe"
+
+#: GeoHealthCheck/plugins/probe/ghcreport.py:115
+msgid "Status summary"
+msgstr ""
 
 #: GeoHealthCheck/templates/add.html:5
 msgid "Add Resource"
@@ -170,86 +176,98 @@ msgid "Active"
 msgstr "En activité"
 
 #: GeoHealthCheck/templates/edit_resource.html:23
+msgid "Authentication"
+msgstr ""
+
+#: GeoHealthCheck/templates/edit_resource.html:26
+msgid "Select optional authentication method and applicable credentials"
+msgstr ""
+
+#: GeoHealthCheck/templates/edit_resource.html:67
 msgid "Notify emails"
 msgstr "Notifiez les emails"
 
-#: GeoHealthCheck/templates/edit_resource.html:25
+#: GeoHealthCheck/templates/edit_resource.html:69
 msgid "You can enter multiple emails separated with comma"
 msgstr "Vous pouvez saisir plusieurs courriels séparés par des virgules"
 
-#: GeoHealthCheck/templates/edit_resource.html:31
+#: GeoHealthCheck/templates/edit_resource.html:75
 msgid "Notify webhooks"
 msgstr "Notifiez les personnalisations"
 
-#: GeoHealthCheck/templates/edit_resource.html:44
+#: GeoHealthCheck/templates/edit_resource.html:88
 msgid "Enter url for webhook."
 msgstr "Saisissez une URL de personnalisation."
 
-#: GeoHealthCheck/templates/edit_resource.html:45
+#: GeoHealthCheck/templates/edit_resource.html:89
 msgid "Optionally, enter payload as list of key=value lines or JSON object."
 msgstr ""
 "Optionnellement, saisissez en complément une liste de lignes clé=valeur "
 "ou un objet JSON."
 
-#: GeoHealthCheck/templates/edit_resource.html:66
+#: GeoHealthCheck/templates/edit_resource.html:110
 #: GeoHealthCheck/templates/resource.html:62
+#: GeoHealthCheck/templates/status_report_email.txt:19
 msgid "Owner"
 msgstr "Propriétaire"
 
-#: GeoHealthCheck/templates/edit_resource.html:71
+#: GeoHealthCheck/templates/edit_resource.html:115
 #: GeoHealthCheck/templates/includes/resources_list.html:5
 #: GeoHealthCheck/templates/resource.html:67
 msgid "Name"
 msgstr "Nom"
 
-#: GeoHealthCheck/templates/edit_resource.html:92
+#: GeoHealthCheck/templates/edit_resource.html:136
 #: GeoHealthCheck/templates/resource.html:86
 msgid "Run Every"
 msgstr ""
 
-#: GeoHealthCheck/templates/edit_resource.html:94
+#: GeoHealthCheck/templates/edit_resource.html:138
 #: GeoHealthCheck/templates/resource.html:88
 msgid "minutes"
 msgstr "minutes"
 
-#: GeoHealthCheck/templates/edit_resource.html:120
+#: GeoHealthCheck/templates/edit_resource.html:164
 #: GeoHealthCheck/templates/includes/resources_list.html:6
+#: GeoHealthCheck/templates/status_report_email.txt:8
+#: GeoHealthCheck/templates/status_report_email.txt:27
 msgid "Status"
 msgstr "État"
 
-#: GeoHealthCheck/templates/edit_resource.html:124
+#: GeoHealthCheck/templates/edit_resource.html:168
 #: GeoHealthCheck/templates/includes/resources_list.html:29
 #: GeoHealthCheck/templates/includes/resources_list.html:38
 #: GeoHealthCheck/templates/notification_email.txt:10
 #: GeoHealthCheck/templates/notification_email.txt:16
+#: GeoHealthCheck/templates/status_report_email.txt:20
 msgid "Details"
 msgstr "Détails"
 
-#: GeoHealthCheck/templates/edit_resource.html:134
-#: GeoHealthCheck/templates/edit_resource.html:340
-#: GeoHealthCheck/templates/edit_resource.html:357
+#: GeoHealthCheck/templates/edit_resource.html:178
+#: GeoHealthCheck/templates/edit_resource.html:418
+#: GeoHealthCheck/templates/edit_resource.html:436
 msgid "Save"
 msgstr "Enregistrer"
 
-#: GeoHealthCheck/templates/edit_resource.html:135
-#: GeoHealthCheck/templates/edit_resource.html:370
-#: GeoHealthCheck/templates/edit_resource.html:378
-#: GeoHealthCheck/templates/edit_resource.html:385
+#: GeoHealthCheck/templates/edit_resource.html:179
+#: GeoHealthCheck/templates/edit_resource.html:449
+#: GeoHealthCheck/templates/edit_resource.html:457
+#: GeoHealthCheck/templates/edit_resource.html:464
 msgid "Test"
 msgstr "Tester"
 
-#: GeoHealthCheck/templates/edit_resource.html:136
+#: GeoHealthCheck/templates/edit_resource.html:180
 msgid "Cancel"
 msgstr "Annuler"
 
-#: GeoHealthCheck/templates/edit_resource.html:137
+#: GeoHealthCheck/templates/edit_resource.html:181
 #: GeoHealthCheck/templates/includes/check_edit_form.html:12
 #: GeoHealthCheck/templates/includes/probe_edit_form.html:126
 #: GeoHealthCheck/templates/resource.html:47
 msgid "Delete"
 msgstr "Supprimer"
 
-#: GeoHealthCheck/templates/edit_resource.html:405
+#: GeoHealthCheck/templates/edit_resource.html:484
 #: GeoHealthCheck/templates/resource.html:191
 msgid "Delete resource"
 msgstr "Supprimer la ressource"
@@ -263,6 +281,7 @@ msgid "Failing Resources"
 msgstr "Ressources en échec"
 
 #: GeoHealthCheck/templates/home.html:23
+#: GeoHealthCheck/templates/status_report_email.txt:22
 msgid "None"
 msgstr "Aucun"
 
@@ -290,40 +309,44 @@ msgid "Resource Types"
 msgstr "Types de ressources"
 
 #: GeoHealthCheck/templates/layout.html:84
-#: GeoHealthCheck/templates/layout.html:99
+#: GeoHealthCheck/templates/layout.html:102
 msgid "Show All"
 msgstr "Montrer tout"
 
-#: GeoHealthCheck/templates/layout.html:90
+#: GeoHealthCheck/templates/layout.html:86
+msgid "Show Mine"
+msgstr ""
+
+#: GeoHealthCheck/templates/layout.html:93
 msgid "Tags"
 msgstr "Mots-clés"
 
-#: GeoHealthCheck/templates/layout.html:105
+#: GeoHealthCheck/templates/layout.html:108
 msgid "Settings"
 msgstr "Paramètres"
 
-#: GeoHealthCheck/templates/layout.html:107
+#: GeoHealthCheck/templates/layout.html:110
 #: GeoHealthCheck/templates/resource.html:149
 msgid "History"
 msgstr "Historique"
 
-#: GeoHealthCheck/templates/layout.html:107
+#: GeoHealthCheck/templates/layout.html:110
 msgid "days"
 msgstr "jours"
 
-#: GeoHealthCheck/templates/layout.html:108
+#: GeoHealthCheck/templates/layout.html:111
 msgid "Runner in Webapp"
 msgstr ""
 
-#: GeoHealthCheck/templates/layout.html:109
+#: GeoHealthCheck/templates/layout.html:112
 msgid "Probe Timeout"
 msgstr ""
 
-#: GeoHealthCheck/templates/layout.html:110
+#: GeoHealthCheck/templates/layout.html:113
 msgid "Minimal Run Freq"
 msgstr ""
 
-#: GeoHealthCheck/templates/layout.html:131
+#: GeoHealthCheck/templates/layout.html:134
 #: GeoHealthCheck/templates/opensearch_description.xml:11
 msgid "Powered by"
 msgstr "Motorisé par"
@@ -364,6 +387,7 @@ msgstr "Bonjour : il s'agit d'un message automatisé de"
 
 #: GeoHealthCheck/templates/notification_email.txt:4
 #: GeoHealthCheck/templates/reset_password_email.txt:1
+#: GeoHealthCheck/templates/status_report_email.txt:1
 msgid "service"
 msgstr "service"
 
@@ -454,6 +478,8 @@ msgstr "Max"
 
 #: GeoHealthCheck/templates/includes/resources_list.html:7
 #: GeoHealthCheck/templates/resource.html:112
+#: GeoHealthCheck/templates/status_report_email.txt:12
+#: GeoHealthCheck/templates/status_report_email.txt:17
 msgid "Reliability"
 msgstr "Fiabilité"
 
@@ -507,6 +533,8 @@ msgid "Download"
 msgstr "Télécharger"
 
 #: GeoHealthCheck/templates/resources.html:15
+#: GeoHealthCheck/templates/status_report_email.txt:9
+#: GeoHealthCheck/templates/status_report_email.txt:14
 msgid "Resources"
 msgstr "Ressources"
 
@@ -518,17 +546,56 @@ msgstr "Recherche..."
 msgid "results"
 msgstr "résultats"
 
-#: GeoHealthCheck/templates/includes/overall_status.html:1
-msgid "Dashboard"
-msgstr "Tableau de bord"
+#: GeoHealthCheck/templates/status_report_email.txt:1
+msgid "Hi: this is a status report sent by the"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:2
+msgid "at"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:2
+msgid "for the GeoHealthCheck endpoint at"
+msgstr ""
 
 #: GeoHealthCheck/templates/includes/overall_status.html:3
+#: GeoHealthCheck/templates/status_report_email.txt:4
 msgid "Monitoring Period"
 msgstr "Période de suivi"
 
+#: GeoHealthCheck/templates/status_report_email.txt:5
+msgid "From"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:6
+msgid "To"
+msgstr ""
+
 #: GeoHealthCheck/templates/includes/overall_status.html:20
+#: GeoHealthCheck/templates/status_report_email.txt:10
 msgid "Operational"
 msgstr "Opérationnel"
+
+#: GeoHealthCheck/templates/status_report_email.txt:18
+msgid "URL"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:23
+msgid "Links"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:24
+msgid "Home"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:25
+#: GeoHealthCheck/templates/status_report_email.txt:26
+msgid "Summary"
+msgstr ""
+
+#: GeoHealthCheck/templates/includes/overall_status.html:1
+msgid "Dashboard"
+msgstr "Tableau de bord"
 
 #: GeoHealthCheck/templates/includes/overall_status.html:40
 msgid "Reliable"

--- a/GeoHealthCheck/translations/hr_HR/LC_MESSAGES/messages.po
+++ b/GeoHealthCheck/translations/hr_HR/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/geopython/GeoHealthCheck/issues\n"
-"POT-Creation-Date: 2019-06-17 14:17+0200\n"
+"POT-Creation-Date: 2019-07-19 16:20+0200\n"
 "PO-Revision-Date: 2019-01-04 19:57+0200\n"
 "Last-Translator: Davor Racić <davor.racic@gmail.com>\n"
 "Language: hr_HR\n"
@@ -14,88 +14,88 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
-#: GeoHealthCheck/app.py:456
+#: GeoHealthCheck/app.py:490
 msgid "This site is not configured for self-registration"
 msgstr "Ova stranica nije konfigurirana za registraciju"
 
-#: GeoHealthCheck/app.py:457
+#: GeoHealthCheck/app.py:491
 msgid "Please contact"
 msgstr "Molimo kontaktirajte"
 
-#: GeoHealthCheck/app.py:469
+#: GeoHealthCheck/app.py:503
 msgid "Invalid username or email"
 msgstr "Neispravno korisničko ime ili email"
 
-#: GeoHealthCheck/app.py:482
+#: GeoHealthCheck/app.py:516
 msgid "already registered"
 msgstr "već registriran"
 
-#: GeoHealthCheck/app.py:505
+#: GeoHealthCheck/app.py:539
 msgid "No resources detected"
 msgstr "Resurs nije otkriven"
 
-#: GeoHealthCheck/app.py:519
+#: GeoHealthCheck/app.py:553
 msgid "Service already registered"
 msgstr "Servis je već registriran"
 
-#: GeoHealthCheck/app.py:591
+#: GeoHealthCheck/app.py:625
 msgid "Services registered"
 msgstr "Servisi su registrirani"
 
-#: GeoHealthCheck/app.py:711 GeoHealthCheck/app.py:740
-#: GeoHealthCheck/app.py:767
+#: GeoHealthCheck/app.py:747 GeoHealthCheck/app.py:776
+#: GeoHealthCheck/app.py:804
 msgid "Resource not found"
 msgstr "Izvor nije pronađen"
 
-#: GeoHealthCheck/app.py:720
+#: GeoHealthCheck/app.py:756
 msgid "INFO"
 msgstr "INFO"
 
-#: GeoHealthCheck/app.py:723 GeoHealthCheck/templates/edit_resource.html:361
+#: GeoHealthCheck/app.py:759 GeoHealthCheck/templates/edit_resource.html:440
 msgid "ERROR"
 msgstr "GREŠKA"
 
-#: GeoHealthCheck/app.py:726
+#: GeoHealthCheck/app.py:762
 msgid "Resource tested successfully"
 msgstr "Izvor je uspješno testiran"
 
-#: GeoHealthCheck/app.py:761
+#: GeoHealthCheck/app.py:798
 msgid "You do not have access to delete this resource"
 msgstr "Nemate dozvole potrebne za brisanje ovoga izvora"
 
-#: GeoHealthCheck/app.py:775
+#: GeoHealthCheck/app.py:812
 msgid "Resource deleted"
 msgstr "Izvor je izbrisan"
 
-#: GeoHealthCheck/app.py:859
+#: GeoHealthCheck/app.py:896
 msgid "Invalid username and / or password"
 msgstr "Pogrešno korisničko i / ili zaporka"
 
-#: GeoHealthCheck/app.py:874
+#: GeoHealthCheck/app.py:911
 msgid "Logged out"
 msgstr "Odjavljen"
 
-#: GeoHealthCheck/app.py:895
+#: GeoHealthCheck/app.py:932
 msgid "Invalid email"
 msgstr "Neispravan email"
 
-#: GeoHealthCheck/app.py:916
+#: GeoHealthCheck/app.py:953
 msgid "reset password"
 msgstr "promijeni zaporku"
 
-#: GeoHealthCheck/app.py:931
+#: GeoHealthCheck/app.py:968
 msgid "Password reset link sent via email"
 msgstr "Poveznica za promjenu zaporke poslana putem emaila"
 
-#: GeoHealthCheck/app.py:953
+#: GeoHealthCheck/app.py:990
 msgid "Invalid token"
 msgstr "neispravan token"
 
-#: GeoHealthCheck/app.py:963
+#: GeoHealthCheck/app.py:1000
 msgid "Password required"
 msgstr "potrebna zaporka"
 
-#: GeoHealthCheck/app.py:970
+#: GeoHealthCheck/app.py:1007
 msgid "Update password OK"
 msgstr "promjena zaporke uspješna"
 
@@ -103,11 +103,13 @@ msgstr "promjena zaporke uspješna"
 msgid "Invalid resource type"
 msgstr "Neispravan tip izvora"
 
-#: GeoHealthCheck/healthcheck.py:214 GeoHealthCheck/healthcheck.py:242
+#: GeoHealthCheck/healthcheck.py:216 GeoHealthCheck/healthcheck.py:246
 msgid "for"
 msgstr "za"
 
 #: GeoHealthCheck/notifications.py:239
+#: GeoHealthCheck/templates/status_report_email.txt:11
+#: GeoHealthCheck/templates/status_report_email.txt:14
 msgid "Failing"
 msgstr "Problematično"
 
@@ -122,6 +124,10 @@ msgstr "Još uvijek problematično"
 #: GeoHealthCheck/notifications.py:245 GeoHealthCheck/notifications.py:247
 msgid "Passing"
 msgstr "Prolazi"
+
+#: GeoHealthCheck/plugins/probe/ghcreport.py:115
+msgid "Status summary"
+msgstr ""
 
 #: GeoHealthCheck/templates/add.html:5
 msgid "Add Resource"
@@ -169,86 +175,98 @@ msgid "Active"
 msgstr "Aktivno"
 
 #: GeoHealthCheck/templates/edit_resource.html:23
+msgid "Authentication"
+msgstr ""
+
+#: GeoHealthCheck/templates/edit_resource.html:26
+msgid "Select optional authentication method and applicable credentials"
+msgstr ""
+
+#: GeoHealthCheck/templates/edit_resource.html:67
 msgid "Notify emails"
 msgstr "Email za obavijesti"
 
-#: GeoHealthCheck/templates/edit_resource.html:25
+#: GeoHealthCheck/templates/edit_resource.html:69
 msgid "You can enter multiple emails separated with comma"
 msgstr "Možete unijeti više e-mailova odvojenih zarezima"
 
-#: GeoHealthCheck/templates/edit_resource.html:31
+#: GeoHealthCheck/templates/edit_resource.html:75
 msgid "Notify webhooks"
 msgstr "Webhookovi za obavijesti"
 
-#: GeoHealthCheck/templates/edit_resource.html:44
+#: GeoHealthCheck/templates/edit_resource.html:88
 msgid "Enter url for webhook."
 msgstr "URL webhook-a"
 
-#: GeoHealthCheck/templates/edit_resource.html:45
+#: GeoHealthCheck/templates/edit_resource.html:89
 msgid "Optionally, enter payload as list of key=value lines or JSON object."
 msgstr ""
 "Ukoliko postoji opcije, unesi payload kao listu key=value linija ili JSOn"
 " objekt"
 
-#: GeoHealthCheck/templates/edit_resource.html:66
+#: GeoHealthCheck/templates/edit_resource.html:110
 #: GeoHealthCheck/templates/resource.html:62
+#: GeoHealthCheck/templates/status_report_email.txt:19
 msgid "Owner"
 msgstr "Vlasnik"
 
-#: GeoHealthCheck/templates/edit_resource.html:71
+#: GeoHealthCheck/templates/edit_resource.html:115
 #: GeoHealthCheck/templates/includes/resources_list.html:5
 #: GeoHealthCheck/templates/resource.html:67
 msgid "Name"
 msgstr "Ime"
 
-#: GeoHealthCheck/templates/edit_resource.html:92
+#: GeoHealthCheck/templates/edit_resource.html:136
 #: GeoHealthCheck/templates/resource.html:86
 msgid "Run Every"
 msgstr "Pokreni svakih"
 
-#: GeoHealthCheck/templates/edit_resource.html:94
+#: GeoHealthCheck/templates/edit_resource.html:138
 #: GeoHealthCheck/templates/resource.html:88
 msgid "minutes"
 msgstr "minuta"
 
-#: GeoHealthCheck/templates/edit_resource.html:120
+#: GeoHealthCheck/templates/edit_resource.html:164
 #: GeoHealthCheck/templates/includes/resources_list.html:6
+#: GeoHealthCheck/templates/status_report_email.txt:8
+#: GeoHealthCheck/templates/status_report_email.txt:27
 msgid "Status"
 msgstr "Status"
 
-#: GeoHealthCheck/templates/edit_resource.html:124
+#: GeoHealthCheck/templates/edit_resource.html:168
 #: GeoHealthCheck/templates/includes/resources_list.html:29
 #: GeoHealthCheck/templates/includes/resources_list.html:38
 #: GeoHealthCheck/templates/notification_email.txt:10
 #: GeoHealthCheck/templates/notification_email.txt:16
+#: GeoHealthCheck/templates/status_report_email.txt:20
 msgid "Details"
 msgstr "Detalji"
 
-#: GeoHealthCheck/templates/edit_resource.html:134
-#: GeoHealthCheck/templates/edit_resource.html:340
-#: GeoHealthCheck/templates/edit_resource.html:357
+#: GeoHealthCheck/templates/edit_resource.html:178
+#: GeoHealthCheck/templates/edit_resource.html:418
+#: GeoHealthCheck/templates/edit_resource.html:436
 msgid "Save"
 msgstr "Spremi"
 
-#: GeoHealthCheck/templates/edit_resource.html:135
-#: GeoHealthCheck/templates/edit_resource.html:370
-#: GeoHealthCheck/templates/edit_resource.html:378
-#: GeoHealthCheck/templates/edit_resource.html:385
+#: GeoHealthCheck/templates/edit_resource.html:179
+#: GeoHealthCheck/templates/edit_resource.html:449
+#: GeoHealthCheck/templates/edit_resource.html:457
+#: GeoHealthCheck/templates/edit_resource.html:464
 msgid "Test"
 msgstr "Test"
 
-#: GeoHealthCheck/templates/edit_resource.html:136
+#: GeoHealthCheck/templates/edit_resource.html:180
 msgid "Cancel"
 msgstr "Odustani"
 
-#: GeoHealthCheck/templates/edit_resource.html:137
+#: GeoHealthCheck/templates/edit_resource.html:181
 #: GeoHealthCheck/templates/includes/check_edit_form.html:12
 #: GeoHealthCheck/templates/includes/probe_edit_form.html:126
 #: GeoHealthCheck/templates/resource.html:47
 msgid "Delete"
 msgstr "Izbriši"
 
-#: GeoHealthCheck/templates/edit_resource.html:405
+#: GeoHealthCheck/templates/edit_resource.html:484
 #: GeoHealthCheck/templates/resource.html:191
 msgid "Delete resource"
 msgstr "Izbriši resurs"
@@ -262,6 +280,7 @@ msgid "Failing Resources"
 msgstr "Nepouzdani resursi"
 
 #: GeoHealthCheck/templates/home.html:23
+#: GeoHealthCheck/templates/status_report_email.txt:22
 msgid "None"
 msgstr "Ništa"
 
@@ -289,40 +308,44 @@ msgid "Resource Types"
 msgstr "Tip resursa"
 
 #: GeoHealthCheck/templates/layout.html:84
-#: GeoHealthCheck/templates/layout.html:99
+#: GeoHealthCheck/templates/layout.html:102
 msgid "Show All"
 msgstr "Prikaži sve"
 
-#: GeoHealthCheck/templates/layout.html:90
+#: GeoHealthCheck/templates/layout.html:86
+msgid "Show Mine"
+msgstr ""
+
+#: GeoHealthCheck/templates/layout.html:93
 msgid "Tags"
 msgstr "Tag-ovi"
 
-#: GeoHealthCheck/templates/layout.html:105
+#: GeoHealthCheck/templates/layout.html:108
 msgid "Settings"
 msgstr "Postavke"
 
-#: GeoHealthCheck/templates/layout.html:107
+#: GeoHealthCheck/templates/layout.html:110
 #: GeoHealthCheck/templates/resource.html:149
 msgid "History"
 msgstr "Povijest"
 
-#: GeoHealthCheck/templates/layout.html:107
+#: GeoHealthCheck/templates/layout.html:110
 msgid "days"
 msgstr "dana"
 
-#: GeoHealthCheck/templates/layout.html:108
+#: GeoHealthCheck/templates/layout.html:111
 msgid "Runner in Webapp"
 msgstr "Pokretač u webapp"
 
-#: GeoHealthCheck/templates/layout.html:109
+#: GeoHealthCheck/templates/layout.html:112
 msgid "Probe Timeout"
 msgstr "istekao test"
 
-#: GeoHealthCheck/templates/layout.html:110
+#: GeoHealthCheck/templates/layout.html:113
 msgid "Minimal Run Freq"
 msgstr "Minimalna frekvencija pokretanja"
 
-#: GeoHealthCheck/templates/layout.html:131
+#: GeoHealthCheck/templates/layout.html:134
 #: GeoHealthCheck/templates/opensearch_description.xml:11
 msgid "Powered by"
 msgstr "Razvijeno od"
@@ -363,6 +386,7 @@ msgstr "Pozdrav: ovo je automatska poruka od"
 
 #: GeoHealthCheck/templates/notification_email.txt:4
 #: GeoHealthCheck/templates/reset_password_email.txt:1
+#: GeoHealthCheck/templates/status_report_email.txt:1
 msgid "service"
 msgstr "servis"
 
@@ -453,6 +477,8 @@ msgstr "Max"
 
 #: GeoHealthCheck/templates/includes/resources_list.html:7
 #: GeoHealthCheck/templates/resource.html:112
+#: GeoHealthCheck/templates/status_report_email.txt:12
+#: GeoHealthCheck/templates/status_report_email.txt:17
 msgid "Reliability"
 msgstr "Pouzdanost"
 
@@ -506,6 +532,8 @@ msgid "Download"
 msgstr "Preuzmi"
 
 #: GeoHealthCheck/templates/resources.html:15
+#: GeoHealthCheck/templates/status_report_email.txt:9
+#: GeoHealthCheck/templates/status_report_email.txt:14
 msgid "Resources"
 msgstr "Resursi"
 
@@ -517,17 +545,56 @@ msgstr "Pretraži..."
 msgid "results"
 msgstr "rezultati"
 
-#: GeoHealthCheck/templates/includes/overall_status.html:1
-msgid "Dashboard"
-msgstr "Radna ploča"
+#: GeoHealthCheck/templates/status_report_email.txt:1
+msgid "Hi: this is a status report sent by the"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:2
+msgid "at"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:2
+msgid "for the GeoHealthCheck endpoint at"
+msgstr ""
 
 #: GeoHealthCheck/templates/includes/overall_status.html:3
+#: GeoHealthCheck/templates/status_report_email.txt:4
 msgid "Monitoring Period"
 msgstr "Period monitoriranja"
 
+#: GeoHealthCheck/templates/status_report_email.txt:5
+msgid "From"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:6
+msgid "To"
+msgstr ""
+
 #: GeoHealthCheck/templates/includes/overall_status.html:20
+#: GeoHealthCheck/templates/status_report_email.txt:10
 msgid "Operational"
 msgstr "Operacionalan"
+
+#: GeoHealthCheck/templates/status_report_email.txt:18
+msgid "URL"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:23
+msgid "Links"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:24
+msgid "Home"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:25
+#: GeoHealthCheck/templates/status_report_email.txt:26
+msgid "Summary"
+msgstr ""
+
+#: GeoHealthCheck/templates/includes/overall_status.html:1
+msgid "Dashboard"
+msgstr "Radna ploča"
 
 #: GeoHealthCheck/templates/includes/overall_status.html:40
 msgid "Reliable"

--- a/GeoHealthCheck/translations/nl_NL/LC_MESSAGES/messages.po
+++ b/GeoHealthCheck/translations/nl_NL/LC_MESSAGES/messages.po
@@ -1,11 +1,10 @@
 # Translators:
 # Just van den Broecke 2016+
-
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/geopython/GeoHealthCheck/issues\n"
-"POT-Creation-Date: 2019-06-17 14:17+0200\n"
+"POT-Creation-Date: 2019-07-19 16:20+0200\n"
 "PO-Revision-Date: 2015-07-25 19:57+0200\n"
 "Last-Translator: Just van den Broecke <justb4@gmail.com>\n"
 "Language: nl_NL\n"
@@ -16,88 +15,88 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
-#: GeoHealthCheck/app.py:456
+#: GeoHealthCheck/app.py:490
 msgid "This site is not configured for self-registration"
 msgstr "Deze site is niet geconfigureerd voor zelf-registratie"
 
-#: GeoHealthCheck/app.py:457
+#: GeoHealthCheck/app.py:491
 msgid "Please contact"
 msgstr "Contacteer"
 
-#: GeoHealthCheck/app.py:469
+#: GeoHealthCheck/app.py:503
 msgid "Invalid username or email"
 msgstr "Ongeldige naam of email"
 
-#: GeoHealthCheck/app.py:482
+#: GeoHealthCheck/app.py:516
 msgid "already registered"
 msgstr "reeds geregistreerd"
 
-#: GeoHealthCheck/app.py:505
+#: GeoHealthCheck/app.py:539
 msgid "No resources detected"
 msgstr "Geen resources gevonden"
 
-#: GeoHealthCheck/app.py:519
+#: GeoHealthCheck/app.py:553
 msgid "Service already registered"
 msgstr "Service reeds geregistreerd"
 
-#: GeoHealthCheck/app.py:591
+#: GeoHealthCheck/app.py:625
 msgid "Services registered"
 msgstr "Service geregistreerd"
 
-#: GeoHealthCheck/app.py:711 GeoHealthCheck/app.py:740
-#: GeoHealthCheck/app.py:767
+#: GeoHealthCheck/app.py:747 GeoHealthCheck/app.py:776
+#: GeoHealthCheck/app.py:804
 msgid "Resource not found"
 msgstr "Bron niet gevonden"
 
-#: GeoHealthCheck/app.py:720
+#: GeoHealthCheck/app.py:756
 msgid "INFO"
 msgstr "INFO"
 
-#: GeoHealthCheck/app.py:723 GeoHealthCheck/templates/edit_resource.html:361
+#: GeoHealthCheck/app.py:759 GeoHealthCheck/templates/edit_resource.html:440
 msgid "ERROR"
 msgstr "FOUT"
 
-#: GeoHealthCheck/app.py:726
+#: GeoHealthCheck/app.py:762
 msgid "Resource tested successfully"
 msgstr "Bron succesvol getest"
 
-#: GeoHealthCheck/app.py:761
+#: GeoHealthCheck/app.py:798
 msgid "You do not have access to delete this resource"
 msgstr "U heeft geen permissie om deze bron te verwijderen"
 
-#: GeoHealthCheck/app.py:775
+#: GeoHealthCheck/app.py:812
 msgid "Resource deleted"
 msgstr "Bron verwijderd"
 
-#: GeoHealthCheck/app.py:859
+#: GeoHealthCheck/app.py:896
 msgid "Invalid username and / or password"
 msgstr "Foutieve gebruikersnaam en / of wachtwoord"
 
-#: GeoHealthCheck/app.py:874
+#: GeoHealthCheck/app.py:911
 msgid "Logged out"
 msgstr "Uitgelogd"
 
-#: GeoHealthCheck/app.py:895
+#: GeoHealthCheck/app.py:932
 msgid "Invalid email"
 msgstr "Ongeldig email adres"
 
-#: GeoHealthCheck/app.py:916
+#: GeoHealthCheck/app.py:953
 msgid "reset password"
 msgstr "reset wachtwoord"
 
-#: GeoHealthCheck/app.py:931
+#: GeoHealthCheck/app.py:968
 msgid "Password reset link sent via email"
 msgstr "Wachtwoord reset link verzonden per email"
 
-#: GeoHealthCheck/app.py:953
+#: GeoHealthCheck/app.py:990
 msgid "Invalid token"
 msgstr "Ongeldig token"
 
-#: GeoHealthCheck/app.py:963
+#: GeoHealthCheck/app.py:1000
 msgid "Password required"
 msgstr "Wachtwoord vereist"
 
-#: GeoHealthCheck/app.py:970
+#: GeoHealthCheck/app.py:1007
 msgid "Update password OK"
 msgstr "Update wachtwoord OK"
 
@@ -105,11 +104,13 @@ msgstr "Update wachtwoord OK"
 msgid "Invalid resource type"
 msgstr "Ongeldig bron type"
 
-#: GeoHealthCheck/healthcheck.py:214 GeoHealthCheck/healthcheck.py:242
+#: GeoHealthCheck/healthcheck.py:216 GeoHealthCheck/healthcheck.py:246
 msgid "for"
 msgstr "voor"
 
 #: GeoHealthCheck/notifications.py:239
+#: GeoHealthCheck/templates/status_report_email.txt:11
+#: GeoHealthCheck/templates/status_report_email.txt:14
 msgid "Failing"
 msgstr "Falend"
 
@@ -124,6 +125,10 @@ msgstr "Nog steeds falend"
 #: GeoHealthCheck/notifications.py:245 GeoHealthCheck/notifications.py:247
 msgid "Passing"
 msgstr "Geslaagd"
+
+#: GeoHealthCheck/plugins/probe/ghcreport.py:115
+msgid "Status summary"
+msgstr ""
 
 #: GeoHealthCheck/templates/add.html:5
 msgid "Add Resource"
@@ -165,6 +170,11 @@ msgstr "Bewerken"
 msgid "Type"
 msgstr "Type"
 
+#: GeoHealthCheck/templates/edit_resource.html:15
+#: GeoHealthCheck/templates/resource.html:58
+msgid "Active"
+msgstr "Aktief"
+
 #: GeoHealthCheck/templates/edit_resource.html:23
 msgid "Authentication"
 msgstr "Authenticatie"
@@ -173,90 +183,89 @@ msgstr "Authenticatie"
 msgid "Select optional authentication method and applicable credentials"
 msgstr "Selecteer optioneel een authenticatie methode en bijbehorende gegevens"
 
-#: GeoHealthCheck/templates/edit_resource.html:15
-#: GeoHealthCheck/templates/resource.html:58
-msgid "Active"
-msgstr "Aktief"
-
-#: GeoHealthCheck/templates/edit_resource.html:23
+#: GeoHealthCheck/templates/edit_resource.html:67
 msgid "Notify emails"
 msgstr "Notificatie emails"
 
-#: GeoHealthCheck/templates/edit_resource.html:25
+#: GeoHealthCheck/templates/edit_resource.html:69
 msgid "You can enter multiple emails separated with comma"
 msgstr "U kunt meerdere email adressen gescheiden met komma invoeren"
 
-#: GeoHealthCheck/templates/edit_resource.html:31
+#: GeoHealthCheck/templates/edit_resource.html:75
 msgid "Notify webhooks"
 msgstr "Notificatie webhooks"
 
-#: GeoHealthCheck/templates/edit_resource.html:44
+#: GeoHealthCheck/templates/edit_resource.html:88
 msgid "Enter url for webhook."
 msgstr "Voer url voor webhook in"
 
-#: GeoHealthCheck/templates/edit_resource.html:45
+#: GeoHealthCheck/templates/edit_resource.html:89
 msgid "Optionally, enter payload as list of key=value lines or JSON object."
 msgstr "Optioneel voeg payload toe als lijst van key=value paren of JSON object"
 
-#: GeoHealthCheck/templates/edit_resource.html:66
+#: GeoHealthCheck/templates/edit_resource.html:110
 #: GeoHealthCheck/templates/resource.html:62
+#: GeoHealthCheck/templates/status_report_email.txt:19
 msgid "Owner"
 msgstr "Eigenaar"
 
-#: GeoHealthCheck/templates/edit_resource.html:71
+#: GeoHealthCheck/templates/edit_resource.html:115
 #: GeoHealthCheck/templates/includes/resources_list.html:5
 #: GeoHealthCheck/templates/resource.html:67
 msgid "Name"
 msgstr "Naam"
 
-#: GeoHealthCheck/templates/edit_resource.html:92
+#: GeoHealthCheck/templates/edit_resource.html:136
 #: GeoHealthCheck/templates/resource.html:86
 msgid "Run Every"
 msgstr "Run Elke"
 
-#: GeoHealthCheck/templates/edit_resource.html:94
+#: GeoHealthCheck/templates/edit_resource.html:138
 #: GeoHealthCheck/templates/resource.html:88
 msgid "minutes"
 msgstr "minuten"
 
-#: GeoHealthCheck/templates/edit_resource.html:120
+#: GeoHealthCheck/templates/edit_resource.html:164
 #: GeoHealthCheck/templates/includes/resources_list.html:6
+#: GeoHealthCheck/templates/status_report_email.txt:8
+#: GeoHealthCheck/templates/status_report_email.txt:27
 msgid "Status"
 msgstr "Status"
 
-#: GeoHealthCheck/templates/edit_resource.html:124
+#: GeoHealthCheck/templates/edit_resource.html:168
 #: GeoHealthCheck/templates/includes/resources_list.html:29
 #: GeoHealthCheck/templates/includes/resources_list.html:38
 #: GeoHealthCheck/templates/notification_email.txt:10
 #: GeoHealthCheck/templates/notification_email.txt:16
+#: GeoHealthCheck/templates/status_report_email.txt:20
 msgid "Details"
 msgstr "Details"
 
-#: GeoHealthCheck/templates/edit_resource.html:134
-#: GeoHealthCheck/templates/edit_resource.html:340
-#: GeoHealthCheck/templates/edit_resource.html:357
+#: GeoHealthCheck/templates/edit_resource.html:178
+#: GeoHealthCheck/templates/edit_resource.html:418
+#: GeoHealthCheck/templates/edit_resource.html:436
 msgid "Save"
 msgstr "Bewaar"
 
-#: GeoHealthCheck/templates/edit_resource.html:135
-#: GeoHealthCheck/templates/edit_resource.html:370
-#: GeoHealthCheck/templates/edit_resource.html:378
-#: GeoHealthCheck/templates/edit_resource.html:385
+#: GeoHealthCheck/templates/edit_resource.html:179
+#: GeoHealthCheck/templates/edit_resource.html:449
+#: GeoHealthCheck/templates/edit_resource.html:457
+#: GeoHealthCheck/templates/edit_resource.html:464
 msgid "Test"
 msgstr "Test"
 
-#: GeoHealthCheck/templates/edit_resource.html:136
+#: GeoHealthCheck/templates/edit_resource.html:180
 msgid "Cancel"
 msgstr "Annuleer"
 
-#: GeoHealthCheck/templates/edit_resource.html:137
+#: GeoHealthCheck/templates/edit_resource.html:181
 #: GeoHealthCheck/templates/includes/check_edit_form.html:12
 #: GeoHealthCheck/templates/includes/probe_edit_form.html:126
 #: GeoHealthCheck/templates/resource.html:47
 msgid "Delete"
 msgstr "Verwijder"
 
-#: GeoHealthCheck/templates/edit_resource.html:405
+#: GeoHealthCheck/templates/edit_resource.html:484
 #: GeoHealthCheck/templates/resource.html:191
 msgid "Delete resource"
 msgstr "Verwijder bron"
@@ -270,6 +279,7 @@ msgid "Failing Resources"
 msgstr "Falende Resources"
 
 #: GeoHealthCheck/templates/home.html:23
+#: GeoHealthCheck/templates/status_report_email.txt:22
 msgid "None"
 msgstr "Geen"
 
@@ -297,7 +307,7 @@ msgid "Resource Types"
 msgstr "Bron Typen"
 
 #: GeoHealthCheck/templates/layout.html:84
-#: GeoHealthCheck/templates/layout.html:99
+#: GeoHealthCheck/templates/layout.html:102
 msgid "Show All"
 msgstr "Allen Tonen"
 
@@ -305,36 +315,36 @@ msgstr "Allen Tonen"
 msgid "Show Mine"
 msgstr "Toon Eigen"
 
-#: GeoHealthCheck/templates/layout.html:90
+#: GeoHealthCheck/templates/layout.html:93
 msgid "Tags"
 msgstr "Tags"
 
-#: GeoHealthCheck/templates/layout.html:105
+#: GeoHealthCheck/templates/layout.html:108
 msgid "Settings"
 msgstr "Instellingen"
 
-#: GeoHealthCheck/templates/layout.html:107
+#: GeoHealthCheck/templates/layout.html:110
 #: GeoHealthCheck/templates/resource.html:149
 msgid "History"
 msgstr "Historie"
 
-#: GeoHealthCheck/templates/layout.html:107
+#: GeoHealthCheck/templates/layout.html:110
 msgid "days"
 msgstr "dagen"
 
-#: GeoHealthCheck/templates/layout.html:108
+#: GeoHealthCheck/templates/layout.html:111
 msgid "Runner in Webapp"
 msgstr "Runner in Webapp"
 
-#: GeoHealthCheck/templates/layout.html:109
+#: GeoHealthCheck/templates/layout.html:112
 msgid "Probe Timeout"
 msgstr "Probe timeout"
 
-#: GeoHealthCheck/templates/layout.html:110
+#: GeoHealthCheck/templates/layout.html:113
 msgid "Minimal Run Freq"
 msgstr "Minimale Run Freq"
 
-#: GeoHealthCheck/templates/layout.html:131
+#: GeoHealthCheck/templates/layout.html:134
 #: GeoHealthCheck/templates/opensearch_description.xml:11
 msgid "Powered by"
 msgstr "Aangedreven door"
@@ -375,6 +385,7 @@ msgstr "Hallo: dit is een automatisch bericht van de"
 
 #: GeoHealthCheck/templates/notification_email.txt:4
 #: GeoHealthCheck/templates/reset_password_email.txt:1
+#: GeoHealthCheck/templates/status_report_email.txt:1
 msgid "service"
 msgstr "service"
 
@@ -465,6 +476,8 @@ msgstr "Max"
 
 #: GeoHealthCheck/templates/includes/resources_list.html:7
 #: GeoHealthCheck/templates/resource.html:112
+#: GeoHealthCheck/templates/status_report_email.txt:12
+#: GeoHealthCheck/templates/status_report_email.txt:17
 msgid "Reliability"
 msgstr "Gezondheid"
 
@@ -518,6 +531,8 @@ msgid "Download"
 msgstr "Download"
 
 #: GeoHealthCheck/templates/resources.html:15
+#: GeoHealthCheck/templates/status_report_email.txt:9
+#: GeoHealthCheck/templates/status_report_email.txt:14
 msgid "Resources"
 msgstr "Bronnen"
 
@@ -529,17 +544,56 @@ msgstr "Zoeken..."
 msgid "results"
 msgstr "resultaten"
 
-#: GeoHealthCheck/templates/includes/overall_status.html:1
-msgid "Dashboard"
-msgstr "Dashboard"
+#: GeoHealthCheck/templates/status_report_email.txt:1
+msgid "Hi: this is a status report sent by the"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:2
+msgid "at"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:2
+msgid "for the GeoHealthCheck endpoint at"
+msgstr ""
 
 #: GeoHealthCheck/templates/includes/overall_status.html:3
+#: GeoHealthCheck/templates/status_report_email.txt:4
 msgid "Monitoring Period"
 msgstr "Monitoring Periode"
 
+#: GeoHealthCheck/templates/status_report_email.txt:5
+msgid "From"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:6
+msgid "To"
+msgstr ""
+
 #: GeoHealthCheck/templates/includes/overall_status.html:20
+#: GeoHealthCheck/templates/status_report_email.txt:10
 msgid "Operational"
 msgstr "Operationeel"
+
+#: GeoHealthCheck/templates/status_report_email.txt:18
+msgid "URL"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:23
+msgid "Links"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:24
+msgid "Home"
+msgstr ""
+
+#: GeoHealthCheck/templates/status_report_email.txt:25
+#: GeoHealthCheck/templates/status_report_email.txt:26
+msgid "Summary"
+msgstr ""
+
+#: GeoHealthCheck/templates/includes/overall_status.html:1
+msgid "Dashboard"
+msgstr "Dashboard"
 
 #: GeoHealthCheck/templates/includes/overall_status.html:40
 msgid "Reliable"

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -105,21 +105,60 @@ In summary there are three options to run GHC and its healthchecks:
 * (deprecated): run **GHC Webapp** with **GHC_RUNNER_IN_WEBAPP** set to `False` and schedule healthchecks via external cron-jobs
 
 
-Enabling or disabling languages
--------------------------------
+Language Translations
+---------------------
 
-Open the file ``GeoHealthCheck/app.py`` and look for the language switcher (e.g. 'en','fr') and remove or add the desired languages.
-In case a new language (e.g. this needs a new translation file called ``*.po``)  is to be added,
-make a copy of  one of the folders in ``GeoHealthCheck/translations/``; rename the folder to the desired language (e.g. 'de' for german);
-start editing the file in ``LC_MESSAGES/messages.po`` and add your translations to the ''msgstr''.
-Don't forget the change the specified language in the messages.po file as well.
-For example the ``messages.po`` file for the german case has an english  ''msgid''  string,
-which needs to be translated in ''msgstr'' as seen below.  ::
+GHC supports multiple languages by using [Babel](http://babel.pocoo.org) with [Flask-Babel](https://pythonhosted.org/Flask-Babel/).
 
-    -#: GeoHealthCheck/app.py:394
-    -msgid "This site is not configured for self-registration"
-    -msgstr "Diese Webseite unterstützt keine Selbstregistrierung"
+*"Babel is an integrated collection of utilities that assist in internationalizing*
+*and localizing Python applications, with an emphasis on web-based applications."*
 
+Enabling/Disabling a Language
+.............................
+
+Open the file `GeoHealthCheck/app.py` and look for the language switcher (e.g. 'en','fr') and remove or add the desired languages.
+In case of a new language, a new translation file (called a `*.po`) has to be added as follows:
+
+* make a copy of one of the folders in `GeoHealthCheck/translations/`;
+* rename the folder to the desired language (e.g. `'de'` for German) using the language ISO codes
+* edit the file `<your_lang>/LC_MESSAGES/messages.po`, adding your translations to the `msgstr`
+
+Don't forget the change the specified language in the `messages.po` file as well.
+For example the `messages.po` file for the German case has an English  `msgid`  string,
+which needs to be translated in `msgstr'` as seen below.  ::
+
+    #: GeoHealthCheck/app.py:394
+    msgid "This site is not configured for self-registration"
+    msgstr "Diese Webseite unterstützt keine Selbstregistrierung"
+
+Compiling Language Files
+........................
+
+At runtime compiled versions, `*.mo` files, of the language-files are used.
+Easiest to compile is via: `paver compile_translations` in the project root dir.
+This basically calls ``pybabel compile` with the proper options.
+Now you can e.g. test your new translations by starting GHC.
+
+Updating Language Files
+.......................
+
+Once a language-file (`.po`) is present, it will need updating as development progresses.
+In order to know what to update (which strings are untranslated) it best to first update the `messages.po` file with
+all language strings, their location(s) within project files and whether the translation is missing.
+Missing translations will have `msgstr ""` like in this excerpt: ::
+
+	#: GeoHealthCheck/notifications.py:245 GeoHealthCheck/notifications.py:247
+	msgid "Passing"
+	msgstr "Jetzt geht's"
+
+	#: GeoHealthCheck/plugins/probe/ghcreport.py:115
+	msgid "Status summary"
+	msgstr ""
+
+Next all empty `msgstr`s can be filled.
+
+Updating is easiest using the command `paver update_translations` within the root dir of the project.
+This will basically call `pybabel extract` followed by `pybabel update` with the proper parameters.
 
 Customizing the Score Matrix
 ----------------------------


### PR DESCRIPTION
This updates all translation files for two things:

* current locations (files/lines) for each `msgid`
* missing translations (`msgstr` empty)

No translations added, just the outcome of `paver update_translations`. Lots of recent stuff added, so was necessary.