### PR TITLE
Issue #9 - Fix auth header setting for WMS Probes

### DIFF
--- a/GeoHealthCheck/app.py
+++ b/GeoHealthCheck/app.py
@@ -826,6 +826,7 @@ def get_probe_edit_form(probe_class, resource_identifier=None):
     if resource_identifier:
         resource = views.get_resource_by_id(resource_identifier)
         if resource:
+            probe_obj._resource = resource
             probe_obj.expand_params(resource)
 
     probe_info = probe_obj.get_plugin_vars()

--- a/GeoHealthCheck/plugins/probe/wms.py
+++ b/GeoHealthCheck/plugins/probe/wms.py
@@ -106,7 +106,8 @@ class WmsGetMapV1(Probe):
         :param version:
         :return: Metadata object
         """
-        return WebMapService(resource.url, version=version)
+        return WebMapService(resource.url, version=version,
+                             headers=self.get_request_headers())
 
     # Overridden: expand param-ranges from WMS metadata
     def expand_params(self, resource):

--- a/GeoHealthCheck/probe.py
+++ b/GeoHealthCheck/probe.py
@@ -79,6 +79,7 @@ class Probe(Plugin):
 
     def __init__(self):
         Plugin.__init__(self)
+        self._resource = None
 
     #
     # Lifecycle : optionally expand params from Resource metadata
@@ -228,6 +229,8 @@ class Probe(Plugin):
         pass
 
     def get_request_headers(self):
+        if not self._resource:
+            return dict()
         return self._resource.add_auth_header(self.REQUEST_HEADERS)
 
     def perform_request(self):

--- a/GeoHealthCheck/views.py
+++ b/GeoHealthCheck/views.py
@@ -229,10 +229,11 @@ def get_probes_avail(resource_type=None, resource=None):
         if probe:
             if resource:
                 try:
+                    probe._resource = resource
                     probe.expand_params(resource)
                 except Exception as err:
                     msg = 'Cannot expand plugin vars for %s err=%s' \
-                          % (probe_class, str(err))
+                          % (probe_class, repr(err))
                     LOGGER.warning(msg)
 
             result[probe_class] = probe.get_plugin_vars()


### PR DESCRIPTION
Applies to issue #9 : not all scenarios were covered: when editing a Probe in some cases fetching metadata dis not set auth headers. Also the resulting error in some cases threw an exception itself because of `str(e)`. 

This fixes at least for WMS. For other OWS Probes we need [this OWSLib issue](https://github.com/geopython/OWSLib/issues/587) to be fixed first to be able to set auth headers. 

Strange: the "translation-commits" were already in master...