### PR TITLE
Include HttpStatusNoError as first Check in most Probes (fixes #299) 

### DIFF
--- a/GeoHealthCheck/plugins/probe/owsgetcaps.py
+++ b/GeoHealthCheck/plugins/probe/owsgetcaps.py
@@ -36,6 +36,9 @@ class OwsGetCaps(Probe):
     """Param defs, to be specified in subclasses"""
 
     CHECKS_AVAIL = {
+        'GeoHealthCheck.plugins.check.checks.HttpStatusNoError': {
+            'default': True
+        },
         'GeoHealthCheck.plugins.check.checks.XmlParse': {
             'default': True
         },

--- a/GeoHealthCheck/plugins/probe/tms.py
+++ b/GeoHealthCheck/plugins/probe/tms.py
@@ -16,6 +16,9 @@ class TmsCaps(Probe):
         Probe.__init__(self)
 
     CHECKS_AVAIL = {
+        'GeoHealthCheck.plugins.check.checks.HttpStatusNoError': {
+            'default': True
+        },
         'GeoHealthCheck.plugins.check.checks.XmlParse': {
             'default': True
         },
@@ -24,7 +27,7 @@ class TmsCaps(Probe):
             'set_params': {
                 'strings': {
                     'name': 'Must contain TileMap Element',
-                    'value': ['<TileMap']
+                    'value': ['TileMap']
                 }
             }
         },

--- a/GeoHealthCheck/plugins/probe/wfs.py
+++ b/GeoHealthCheck/plugins/probe/wfs.py
@@ -88,6 +88,9 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     """Param defs"""
 
     CHECKS_AVAIL = {
+        'GeoHealthCheck.plugins.check.checks.HttpStatusNoError': {
+            'default': True
+        },
         'GeoHealthCheck.plugins.check.checks.XmlParse': {
             'default': True
         },

--- a/GeoHealthCheck/plugins/probe/wms.py
+++ b/GeoHealthCheck/plugins/probe/wms.py
@@ -82,10 +82,13 @@ class WmsGetMapV1(Probe):
     """Param defs"""
 
     CHECKS_AVAIL = {
-        'GeoHealthCheck.plugins.check.checks.HttpHasImageContentType': {
+        'GeoHealthCheck.plugins.check.checks.HttpStatusNoError': {
             'default': True
         },
         'GeoHealthCheck.plugins.check.checks.NotContainsOwsException': {
+            'default': True
+        },
+        'GeoHealthCheck.plugins.check.checks.HttpHasImageContentType': {
             'default': True
         }
     }

--- a/GeoHealthCheck/result.py
+++ b/GeoHealthCheck/result.py
@@ -20,8 +20,9 @@ class Result(object):
         self.results.append(result)
         if not result.success:
             self.success = False
-            self.message = result.message
             self.results_failed.append(result)
+            # First failed result is usually main failure reason
+            self.message = self.results_failed[0].message
 
     def get_report(self):
         return {

--- a/tests/data/resources.json
+++ b/tests/data/resources.json
@@ -203,6 +203,11 @@
     }
   },
   "check_vars": {
+    "PDOK BAG WMS - GetCaps - No HTTP Error": {
+      "probe_vars": "PDOK BAG WMS - GetCaps",
+      "check_class": "GeoHealthCheck.plugins.check.checks.HttpStatusNoError",
+      "parameters": {}
+    },
     "PDOK BAG WMS - GetCaps - XML Parse": {
       "probe_vars": "PDOK BAG WMS - GetCaps",
       "check_class": "GeoHealthCheck.plugins.check.checks.XmlParse",

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -115,7 +115,7 @@ class GeoHealthCheckTest(unittest.TestCase):
         self.assertIsNotNone(plugin_obj)
 
         checks = plugin_obj.CHECKS_AVAIL
-        self.assertEquals(len(checks), 3, 'WmsGetCaps should have 3 Checks')
+        self.assertEquals(len(checks), 4, 'WmsGetCaps should have 4 Checks')
 
         parameters = plugin_obj.PARAM_DEFS
         self.assertEquals(


### PR DESCRIPTION
* include `HttpStatusNoError` `Check`
* also enhance `Result` reporting: with failure list `Message` first failing `Check` e.g. `HttpStatusNoError` (was last)