### PR TITLE
Update requirements.txt

### DIFF
--- a/docker/scripts/requirements.txt
+++ b/docker/scripts/requirements.txt
@@ -2,5 +2,5 @@ Paver==1.3.4
 Sphinx==1.8.1
 psycopg2==2.7.5
 eventlet==0.24.1
-gunicorn==19.9.0
+gunicorn==20.0.4
 lxml==4.3.2

--- a/docker/scripts/requirements.txt
+++ b/docker/scripts/requirements.txt
@@ -4,3 +4,4 @@ psycopg2==2.7.5
 eventlet==0.24.1
 gunicorn==20.0.4
 lxml==4.3.2
+Werkzeug==0.16.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ requests>=2.20.0
 WTForms==2.2.1
 APScheduler==3.6.1
 passlib==1.7.1
-Werkzeug==1.0.0 
+Werkzeug==0.16.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ requests>=2.20.0
 WTForms==2.2.1
 APScheduler==3.6.1
 passlib==1.7.1
-Werkzeug 1.0.0 
+Werkzeug==1.0.0 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ requests>=2.20.0
 WTForms==2.2.1
 APScheduler==3.6.1
 passlib==1.7.1
+Werkzeug 1.0.0 


### PR DESCRIPTION
update gunicorn to 20.0.4
there is a bug in gunicorn 19.0.9 causing the web server to not load the bootstrap.min.css completely.
open Geohealthcheck in chrome or firefox on a windows machine and press ctrl + F5 to replicate the issue 
screenshot of issue: https://imgur.com/eUfxFcR
info: https://github.com/benoitc/gunicorn/issues/615
bug fix: https://github.com/benoitc/gunicorn/releases