### PR TITLE
Fix for #133 use requests Session object with Retry capabilities

### DIFF
--- a/GeoHealthCheck/probe.py
+++ b/GeoHealthCheck/probe.py
@@ -8,6 +8,7 @@ from factory import Factory
 from init import App
 from plugin import Plugin
 from result import ProbeResult
+from util import create_requests_retry_session
 
 LOGGER = logging.getLogger(__name__)
 
@@ -80,6 +81,7 @@ class Probe(Plugin):
     def __init__(self):
         Plugin.__init__(self)
         self._resource = None
+        self._session = create_requests_retry_session()
 
     #
     # Lifecycle : optionally expand params from Resource metadata
@@ -284,14 +286,14 @@ class Probe(Plugin):
 
     def perform_get_request(self, url):
         """ Perform actual HTTP GET request to service"""
-        return requests.get(
+        return self._session.get(
             url,
             timeout=App.get_config()['GHC_PROBE_HTTP_TIMEOUT_SECS'],
             headers=self.get_request_headers())
 
     def perform_post_request(self, url_base, request_string):
         """ Perform actual HTTP POST request to service"""
-        return requests.post(
+        return self._session.post(
             url_base,
             timeout=App.get_config()['GHC_PROBE_HTTP_TIMEOUT_SECS'],
             data=request_string,

--- a/GeoHealthCheck/util.py
+++ b/GeoHealthCheck/util.py
@@ -33,6 +33,9 @@ import logging
 import os
 import smtplib
 import base64
+import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 from urllib.request import urlopen
 from urllib.parse import urlparse
 from gettext import translation
@@ -257,3 +260,25 @@ def decode(key: str, string: str) -> str:
 # d = decode('a key', e)
 # print([e])
 # print([d])
+
+# https://www.peterbe.com/plog/best-practice-with-retries-with-requests
+# Provides a requests Session object with requests' Retry capabilities.
+# TODO: may make numbers below configurable
+def create_requests_retry_session(
+    retries=3,
+    backoff_factor=0.3,
+    status_forcelist=(500, 502, 504),
+    session=None,
+):
+    session = session or requests.Session()
+    retry = Retry(
+        total=retries,
+        read=retries,
+        connect=retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    return session

--- a/GeoHealthCheck/util.py
+++ b/GeoHealthCheck/util.py
@@ -261,6 +261,7 @@ def decode(key: str, string: str) -> str:
 # print([e])
 # print([d])
 
+
 # https://www.peterbe.com/plog/best-practice-with-retries-with-requests
 # Provides a requests Session object with requests' Retry capabilities.
 # TODO: may make numbers below configurable

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ OWSLib==0.17.1  # update to new version when solution to OWSLIB #614 is released
 openapi-spec-validator==0.2.8
 Sphinx==2.2.0
 sphinx-rtd-theme==0.4.3
-requests>=2.20.0
+requests>=2.23.0
 WTForms==2.2.1
 APScheduler==3.6.1
 passlib==1.7.1


### PR DESCRIPTION
This fix should improve HTTP connection handling by GHC `Probes` significantly:

1) use `requests` `Session` objects to reuse connections (works via `urllib3`)
2) implement the golden tip from: https://www.peterbe.com/plog/best-practice-with-retries-with-requests . Within the `Probe` object a `Session` with a retry/backoff schema is created.
3) upgrade `requests` package to latest version **2.23.0**

Especially in Probes where all N Layers of a WMS/Tiling endpoint are accessed/crawled this already gives a factor 3 performance improvement. In the old case a new connection was setup for each request.

The false negatives should be of the past. Will first observe for some time on the GHC demo server (where I get this stream of Failing/Fixed emails constantly...).

OPTION for later: may make this mechanism and its parameters configurable.

