### PR TITLE
#285 #313 Content Negotiation in OAFeat Probes and renaming for OAFeat

### DIFF
--- a/GeoHealthCheck/enums.py
+++ b/GeoHealthCheck/enums.py
@@ -72,7 +72,7 @@ RESOURCE_TYPES = {
         'versions': ['1.0']
     },
     'OGC:WFS3': {
-        'label': 'OGC API Features (WFS3)'
+        'label': 'OGC API Features (OAFeat)'
     },
     'ESRI:FS': {
         'label': 'ESRI ArcGIS FeatureServer (FS)'

--- a/GeoHealthCheck/healthcheck.py
+++ b/GeoHealthCheck/healthcheck.py
@@ -238,7 +238,7 @@ def sniff_test_resource(config, resource_type, url):
             if resource_type == 'OGC:STA':
                 title = 'OGC STA'
             elif resource_type == 'OGC:WFS3':
-                title = 'OGC WFS3 (OAPIF)'
+                title = 'OGC API Features (OAFeat)'
             elif resource_type == 'ESRI:FS':
                 title = 'ESRI ArcGIS FS'
             else:


### PR DESCRIPTION

* Fixes #285 (was forgotten about this one) completely: all OAFeat client requests through OWSLib now enforce JSON responses via proper Accept: HTTP header from endpoint-metadata (`type`), like the landing or collection pages.

* The UI now completely uses official OGC API Features naming convention (no "WFS3" anymore)

Still TODO, but I prefer in separate issues:

* enum `OGC:WFS3` and package class renaming, still uses WFS3, requires DB change, but is all internal.
* implement new `OGCAPIFeaturesCollection` Probe class where a single Collection can be selected (ala WMS Layers)
