### PR TITLE
Fix spaces for notify emails (issue #346)

### DIFF
--- a/GeoHealthCheck/app.py
+++ b/GeoHealthCheck/app.py
@@ -684,11 +684,13 @@ def update(resource_identifier):
 
                 update_counter += 1
             elif key == 'notify_emails':
-                resource.set_recipients('email',
-                                        [v for v in value if v.strip()])
+                resource.set_recipients(
+                    'email',
+                    [v.strip() for v in value if v.strip()])
             elif key == 'notify_webhooks':
-                resource.set_recipients('webhook',
-                                        [v for v in value if v.strip()])
+                resource.set_recipients(
+                    'webhook',
+                    [v.strip() for v in value if v.strip()])
             elif key == 'auth':
                 resource.auth = value
             elif getattr(resource, key) != resource_identifier_dict[key]:

--- a/GeoHealthCheck/templates/edit_resource.html
+++ b/GeoHealthCheck/templates/edit_resource.html
@@ -67,7 +67,7 @@
                 <th>{{ _("Notify emails") }}</th>
                 <td>
                     <label>{{ _('You can enter multiple emails separated with comma') }}</label>
-                    <input type="text" class="form-control" id="input_resource_notify_emails" name="resource_notify_emails_value" value="{{ resource.get_recipients('email')|join(', ') }}"/>
+                    <input type="text" class="form-control" id="input_resource_notify_emails" name="resource_notify_emails_value" value="{{ resource.get_recipients('email')|join(',') }}"/>
                 </td>
             </tr>
 
@@ -349,7 +349,7 @@ or
         var new_active = $('#input_resource_active').prop('checked');
 
         // Collect recipients
-        var new_notify_emails = $('#input_resource_notify_emails').val().split(',');
+        var new_notify_emails = $('#input_resource_notify_emails').val().replace(' ','').split(',');
         var new_notify_webhooks = [];
 
         $('textarea[name="resource_notify_webhooks_value"]').each(function(idx, elm){


### PR DESCRIPTION
The input for the email address for the notification allows for multiply
entries if they are separated by commas. When the form is displayed again,
spaces are added after the commas. The extra spaces generate an error when the
user tries to safe the edits.

This commit fixes:
- no spaces are added when the form is displayed again.
- removes spaces in the email address field before saving.