### PR TITLE
Partial fix for #372: faster shutdown of ghc_web Docker container

### DIFF
--- a/docker/scripts/run-web.sh
+++ b/docker/scripts/run-web.sh
@@ -22,7 +22,7 @@ paver upgrade
 [ "${SCRIPT_NAME}" = '/' ] && export SCRIPT_NAME="" && echo "make SCRIPT_NAME empty from /"
 
 echo "Running GHC WSGI on ${HOST}:${PORT} with ${WSGI_WORKERS} workers and SCRIPT_NAME=${SCRIPT_NAME}"
-gunicorn --workers ${WSGI_WORKERS} \
+exec gunicorn --workers ${WSGI_WORKERS} \
 		--worker-class=${WSGI_WORKER_CLASS} \
 		--timeout ${WSGI_WORKER_TIMEOUT} \
 		--name="Gunicorn_GHC" \


### PR DESCRIPTION
This PR only prepends `exec` before the `gunicorn` command, resulting in the ghc_web Docker container being shut down much faster. No solution for the ghc_runner container though. Putting `exec` before the `paver` command doesn't have any affect, and neither has using `exec` somewhere inside runner_daemon in pavement.sh.