### PR TITLE
PR for #363 enable sphinx autodoc for RTD build

### DIFF
--- a/GeoHealthCheck/init.py
+++ b/GeoHealthCheck/init.py
@@ -67,7 +67,8 @@ class App:
 
         # Read and override configs
         app.config.from_pyfile('config_main.py')
-        app.config.from_pyfile('../instance/config_site.py')
+        app.config.from_pyfile('../instance/config_site.py',
+                               silent=os.environ['SPHINX_BUILD'] == '1')
         app.config.from_envvar('GHC_SETTINGS', silent=True)
 
         # Global Logging config

--- a/GeoHealthCheck/init.py
+++ b/GeoHealthCheck/init.py
@@ -67,8 +67,10 @@ class App:
 
         # Read and override configs
         app.config.from_pyfile('config_main.py')
+        # config_site.py not present in doc-build: silently fail
+        sphinx_build = os.environ.get('SPHINX_BUILD', '0')
         app.config.from_pyfile('../instance/config_site.py',
-                               silent=os.environ['SPHINX_BUILD'] == '1')
+                               silent=sphinx_build == '1')
         app.config.from_envvar('GHC_SETTINGS', silent=True)
 
         # Global Logging config

--- a/docker/scripts/requirements.txt
+++ b/docker/scripts/requirements.txt
@@ -1,5 +1,5 @@
 Paver==1.3.4
 psycopg2==2.7.5
-eventlet==0.24.1
+eventlet==0.31.0
 gunicorn==19.9.0
 Werkzeug==0.16.1


### PR DESCRIPTION
This should fix autodoc (API doc) generation again for ReadTheDocs builds.