### PR TITLE
Partial fix for #389: force tzlocal version lower than 3.0 in Docker image

### DIFF
--- a/docker/scripts/requirements.txt
+++ b/docker/scripts/requirements.txt
@@ -3,3 +3,4 @@ psycopg2==2.7.5
 eventlet==0.30.2
 gunicorn==20.1.0
 Werkzeug==0.16.1
+tzlocal<3.0


### PR DESCRIPTION
See my comments at issue #389 