### PR TITLE
#395 use message and datetime from Run in email notification template

### DIFF
--- a/GeoHealthCheck/templates/notification_email.txt
+++ b/GeoHealthCheck/templates/notification_email.txt
@@ -9,9 +9,9 @@
 
 {{ _('Details') }}:
 
-{{ _('Date') }}: {{ resource.last_run.checked_datetime.strftime('%Y-%m-%dT%H:%M:%SZ') }} 
+{{ _('Date') }}: {{ run.checked_datetime.strftime('%Y-%m-%dT%H:%M:%SZ') }} 
 
-{{ _('Message') }}: {{ resource.last_run.message }}
+{{ _('Message') }}: {{ run.message }}
 
 {{ _('Details') }}: {{ config.GHC_SITE_URL }}/resource/{{resource.identifier}}
 


### PR DESCRIPTION
Quickfix, should solve caching problem with resource.last_run when new Run used.