### PR TITLE
support trailing slashes on Flask routes

### DIFF
--- a/GeoHealthCheck/init.py
+++ b/GeoHealthCheck/init.py
@@ -65,6 +65,8 @@ class App:
         # Do init once
         app = Flask(__name__)
 
+        app.url_map.strict_slashes = False
+
         # Read and override configs
         app.config.from_pyfile('config_main.py')
         # config_site.py not present in doc-build: silently fail


### PR DESCRIPTION
Adds support for trailing slash support to URLs.  When deploying GHC in a docker-compose setup on a port/subpath, the GHC home page would redirect to `/`. This PR fixes the issue.