### PR TITLE
Email TLS fixes

### DIFF
--- a/GeoHealthCheck/notifications.py
+++ b/GeoHealthCheck/notifications.py
@@ -95,22 +95,23 @@ def do_email(config, resource, run, status_changed, result):
     if config['DEBUG']:
         server.set_debuglevel(True)
 
-    try:
-        if config['GHC_SMTP']['tls']:
+    if config['GHC_SMTP']['tls']:
+        LOGGER.debug('Authenticating via TLS')
+        try:
             server.starttls()
-    except Exception as err:
-        LOGGER.exception("Cannot connect to smtp: %s[:%s]: %s",
-                         config['GHC_SMTP']['server'],
-                         config['GHC_SMTP']['port'],
-                         err,
-                         exc_info=err)
-        return
+        except Exception as err:
+            LOGGER.exception("Cannot authenticate to smtp: %s:%s: %s",
+                             config['GHC_SMTP']['server'],
+                             config['GHC_SMTP']['port'],
+                             err,
+                             exc_info=err)
+            return
     try:
         server.login(config['GHC_SMTP']['username'],
                      config['GHC_SMTP']['password'])
     except Exception as err:
-        LOGGER.exception("Cannot log in to smtp: %s", err,
-                         exc_info=err)
+        LOGGER.exception("Cannot log in to smtp: %s", err, exc_info=err)
+
     try:
         server.sendmail(config['GHC_ADMIN_EMAIL'],
                         notifications_email,

--- a/GeoHealthCheck/notifications.py
+++ b/GeoHealthCheck/notifications.py
@@ -100,7 +100,7 @@ def do_email(config, resource, run, status_changed, result):
         try:
             server.starttls()
         except Exception as err:
-            LOGGER.exception("Cannot authenticate to smtp: %s:%s: %s",
+            LOGGER.exception("Cannot authenticate to SMTP: %s:%s: %s",
                              config['GHC_SMTP']['server'],
                              config['GHC_SMTP']['port'],
                              err,
@@ -110,7 +110,8 @@ def do_email(config, resource, run, status_changed, result):
         server.login(config['GHC_SMTP']['username'],
                      config['GHC_SMTP']['password'])
     except Exception as err:
-        LOGGER.exception("Cannot log in to smtp: %s", err, exc_info=err)
+        LOGGER.warning("Cannot log in to SMTP: %s", err, exc_info=err)
+        LOGGER.warning("Will attempt to send mail anyway")
 
     try:
         server.sendmail(config['GHC_ADMIN_EMAIL'],

--- a/GeoHealthCheck/notifications.py
+++ b/GeoHealthCheck/notifications.py
@@ -79,10 +79,7 @@ def do_email(config, resource, run, status_changed, result):
                                       result, resource.title)
 
     if not config.get('GHC_SMTP') or not\
-        (any([config['GHC_SMTP'][k] for k in ('port',
-                                              'server',
-                                              'username',
-                                              'password',)])):
+       (any([config['GHC_SMTP'][k] for k in ('port', 'server',)])):
 
         LOGGER.warning("No SMTP configuration. Not sending to %s",
                        notifications_email)
@@ -106,12 +103,14 @@ def do_email(config, resource, run, status_changed, result):
                              err,
                              exc_info=err)
             return
-    try:
-        server.login(config['GHC_SMTP']['username'],
-                     config['GHC_SMTP']['password'])
-    except Exception as err:
-        LOGGER.warning("Cannot log in to SMTP: %s", err, exc_info=err)
-        LOGGER.warning("Will attempt to send mail anyway")
+
+    if None not in [
+       config['GHC_SMTP'].get('username'), config['GHC_SMTP'].get('password')]:
+        try:
+            server.login(config['GHC_SMTP']['username'],
+                         config['GHC_SMTP']['password'])
+        except Exception as err:
+            LOGGER.exception("Cannot log in to SMTP: %s", err, exc_info=err)
 
     try:
         server.sendmail(config['GHC_ADMIN_EMAIL'],

--- a/docker/config_site.py
+++ b/docker/config_site.py
@@ -33,6 +33,10 @@ def str2bool(v):
     return v.lower() in ("yes", "true", "t", "1")
 
 
+def str2None(v):
+    return None if v == 'None' else v
+
+
 DEBUG = False
 SQLALCHEMY_ECHO = False
 
@@ -78,8 +82,8 @@ GHC_SMTP = {
     'port': os.environ['GHC_SMTP_PORT'],
     'tls': str2bool(os.environ['GHC_SMTP_TLS']),
     'ssl': str2bool(os.environ['GHC_SMTP_SSL']),
-    'username': os.environ['GHC_SMTP_USERNAME'],
-    'password': os.environ['GHC_SMTP_PASSWORD']
+    'username': str2None(os.environ.get('GHC_SMTP_USERNAME')),
+    'password': str2None(os.environ.get('GHC_SMTP_PASSWORD'))
 }
 
 # TODO: provide for GHC Plugins

--- a/docker/config_site.py
+++ b/docker/config_site.py
@@ -76,8 +76,8 @@ if os.environ.get('GHC_USER_PLUGINS'):
 GHC_SMTP = {
     'server': os.environ['GHC_SMTP_SERVER'],
     'port': os.environ['GHC_SMTP_PORT'],
-    'tls': os.environ['GHC_SMTP_TLS'],
-    'ssl': os.environ['GHC_SMTP_SSL'],
+    'tls': str2bool(os.environ['GHC_SMTP_TLS']),
+    'ssl': str2bool(os.environ['GHC_SMTP_SSL']),
     'username': os.environ['GHC_SMTP_USERNAME'],
     'password': os.environ['GHC_SMTP_PASSWORD']
 }


### PR DESCRIPTION
This PR fixes a bug in GHC's Docker setup of `GHC_SMTP_*` environment variables that were not getting cast as booleans, and resulting in `'False'` values evaluating to `True` in GHC notifications.  In addition, TLS handling has been streamlined for better flow and error handling.