### PR TITLE
Use `encodebytes` instead of `encodestring`

### DIFF
--- a/GeoHealthCheck/plugins/resourceauth/resourceauths.py
+++ b/GeoHealthCheck/plugins/resourceauth/resourceauths.py
@@ -101,7 +101,7 @@ class BasicAuth(ResourceAuth):
         # write the Authorization header
         # like: 'Basic base64encode(username + ':' + password)
         auth_creds = self.auth_dict['data']
-        auth_val = base64.encodestring(
+        auth_val = base64.encodebytes(
             '{}:{}'.format(auth_creds['username'], auth_creds['password']).
             encode())
         auth_val = 'Basic {}'.format(auth_val.decode())


### PR DESCRIPTION
`encodestring` was deprecated in 3.1, and removed in 3.9. When I tried running the code in 3.9 it failed, but it's a simple 1:1 swap to fix it