### PR TITLE
Fix CSW HTTP POST Resource URL with body Bug

### DIFF
--- a/GeoHealthCheck/plugins/probe/http.py
+++ b/GeoHealthCheck/plugins/probe/http.py
@@ -88,6 +88,7 @@ class HttpPost(HttpGet):
         # request_headers =
         #       self.REQUEST_HEADERS['content-type'].format(**content_type)
         # Hmm seems simpler
-        headers = Probe.get_request_headers(self)
-        return headers.update(
-            {'Content-Type': self._parameters['content_type']})
+        # headers = Probe.get_request_headers(self)
+        # return headers.update(
+        #    {'Content-Type': self._parameters['content_type']})
+        return {'content-type': self._parameters['content_type']}


### PR DESCRIPTION
The Catalogue Service (CSW) with HTTP POST Resource URL with body - Probe doesn't send a Content-Type and generated a 415 (Unsupported Media Type) Error. It was tested with tcpdump and wireshark and  GeoHealthCheck version 0.8.3. After changing the return value to "{'content-type': self._parameters['content_type']}" of the get_request_headers method the problem was solved.