### PR TITLE
Added a more secure base image and little corrections base on Dockerfile best practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.9-alpine3.11
+FROM python:3.7-alpine 
 
 # Thanks to http://www.sandtable.com/reduce-docker-image-sizes-using-alpine
 # FROM debian:jessie
@@ -76,10 +76,10 @@ RUN apk add --no-cache --virtual .build-deps gcc build-base libxslt-dev libxml2-
 # Add standard files and Add/override Plugins
 # Alternative Entrypoints to run GHC jobs
 # Override default Entrypoint with these on Containers
-ADD docker/scripts/*.sh docker/config_site.py docker/plugins /
+COPY docker/scripts/*.sh docker/config_site.py docker/plugins /
 
 # Add Source Code
-ADD . /GeoHealthCheck
+COPY . /GeoHealthCheck
 
 # Install and Remove build-related packages for smaller image size
 RUN chmod a+x /*.sh && bash install.sh && apk del .build-deps


### PR DESCRIPTION
# Change base image to latest Python 3.7 image and latest Alpine Linux.

The Alpine Linux used is not supported by the maintainers.

## Resume of Snyk scan (docker scan geopython/geohealthcheck:latest):

Tested 55 dependencies for known issues, found 13 issues.

Base Image             Vulnerabilities  Severity
python:3.7-alpine3.11  20               2 critical, 14 high, 3 medium, 1 low

Recommendations for base image upgrade:

Alternative image types
Base Image                   Vulnerabilities  Severity
python:3.7.13-slim           49               1 critical, 0 high, 0 medium, 48 low
python:3.10.4-slim-bullseye  49               1 critical, 0 high, 0 medium, 48 low
python:3.11-rc-slim          49               1 critical, 0 high, 0 medium, 48 low
python:3.11.0b1-slim-buster  84               1 critical, 1 high, 0 medium, 82 low

Alpine 3.11.7 is no longer supported by the Alpine maintainers. Vulnerability detection may be affected by a lack of security updates.

## Using the updated Python 3.7/Alpine 3.16

Organization:      cmotadev
Package manager:   apk
Project name:      docker-image|ndscprm/geohealthcheck
Docker image:      ndscprm/geohealthcheck:latest
Platform:          linux/amd64
Base image:        python:3.7.13-alpine3.16
Licenses:          enabled

✔ Tested 72 dependencies for known issues, no vulnerable paths found.

According to our scan, you are currently using the most secure version of the selected base image

## Dockerfile ADD or COPY

Refer: [https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy)
