### PR TITLE
fix Unit tests Dutch URLs PDOK BAG and Vector Tiles

### DIFF
--- a/tests/data/fixtures.json
+++ b/tests/data/fixtures.json
@@ -117,17 +117,6 @@
       "tags": [
         "esri"
       ]
-    },
-    "PDOK MAPBOX TILEJSON": {
-      "owner": "admin",
-      "resource_type": "Mapbox:TileJSON",
-      "active": true,
-      "title": "PDOK BRT+BGT Mapbox TileJSON",
-      "url": "https://geodata.nationaalgeoregister.nl/beta/topotiles-viewer/styles/tilejson.json",
-      "tags": [
-        "pdok",
-        "tiling"
-      ]
     }
   },
   "probe_vars": {
@@ -303,16 +292,8 @@
       "parameters": {
         "drilldown_level": "full"
       }
-    },
-    "PDOK - MAPBOX TILEJSON": {
-      "resource": "PDOK MAPBOX TILEJSON",
-      "probe_class": "GeoHealthCheck.plugins.probe.mapbox.TileJSON",
-      "parameters": {
-        "lat_4326": "52",
-        "lon_4326": "5"
-      }
     }
-  },
+   },
   "check_vars": {
     "PDOK BAG WMS - GetCaps - XML Parse": {
       "probe_vars": "PDOK BAG WMS - GetCaps",
@@ -414,11 +395,6 @@
     "OPENGEOGROEP TMS - TopTile - Content Type": {
       "probe_vars": "OPENGEOGROEP TMS - TopTile",
       "check_class": "GeoHealthCheck.plugins.check.checks.HttpHasImageContentType",
-      "parameters": {}
-    },
-    "PDOK MAPBOX TILEJSON - HTTP - NoError": {
-      "probe_vars": "PDOK - MAPBOX TILEJSON",
-      "check_class": "GeoHealthCheck.plugins.check.checks.HttpStatusNoError",
       "parameters": {}
     },
     "WOUDC WMTS - GetTileREST - No Exception": {

--- a/tests/data/minimal.json
+++ b/tests/data/minimal.json
@@ -15,7 +15,7 @@
       "resource_type": "OGC:WMS",
       "active": true,
       "title": "PDOK BAG Web Map Service",
-      "url": "https://geodata.nationaalgeoregister.nl/bag/wms/v1_1",
+      "url": "https://service.pdok.nl/lv/bag/wms/v2_0",
       "tags": []
     }
   },

--- a/tests/data/resources.json
+++ b/tests/data/resources.json
@@ -29,7 +29,7 @@
       "resource_type": "OGC:WMS",
       "active": true,
       "title": "PDOK BAG Web Map Service",
-      "url": "https://geodata.nationaalgeoregister.nl/bag/wms/v1_1",
+      "url": "https://service.pdok.nl/lv/bag/wms/v2_0",
       "tags": [
         "ows",
         "pdok"
@@ -40,7 +40,7 @@
       "resource_type": "OGC:WMS",
       "active": true,
       "title": "PDOK BAG Web Map Service",
-      "url": "https://geodata.nationaalgeoregister.nl/bag/wms/v1_1",
+      "url": "https://service.pdok.nl/lv/bag/wms/v2_0",
       "tags": [
         "ows",
         "pdok"

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -60,7 +60,7 @@ class GeoHealthCheckTest(unittest.TestCase):
     def testResourcesPresent(self):
         resources = Resource.query.all()
 
-        self.assertEqual(len(resources), 11)
+        self.assertEqual(len(resources), 10)
 
     def testRunResoures(self):
         # Do the whole healthcheck for all Resources for now


### PR DESCRIPTION
2 problems:

- the BAG WMS URL has changed to https://service.pdok.nl/lv/bag/wms/v2_0
- MapBox Vector Tiles endpoint: https://geodata.nationaalgeoregister.nl/beta/topotiles-viewer/styles/tilejson.json ceases to exist

For the latter there is no replacement URL, as PDOK switched to OGC API Vector Tiles, opened new issue #450 for this. 
