### PR TITLE
Fix update of request headers

### DIFF
--- a/GeoHealthCheck/plugins/probe/http.py
+++ b/GeoHealthCheck/plugins/probe/http.py
@@ -89,5 +89,7 @@ class HttpPost(HttpGet):
         #       self.REQUEST_HEADERS['content-type'].format(**content_type)
         # Hmm seems simpler
         headers = Probe.get_request_headers(self)
-        return headers.update(
+        headers.update(
             {'Content-Type': self._parameters['content_type']})
+
+        return headers


### PR DESCRIPTION
This is a fix to the issue https://github.com/geopython/GeoHealthCheck/issues/459

The `update` function changes the object but always returns None, which resulted in the value returned by `get_request_headers` being empty all the time.

Among other things that could happen, the Authorization header was not being sent, resulting in a 401 status.