### PR TITLE
Make GHC installable on Ubuntu 22.4 and 24.4 / Python 3.12

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -51,7 +51,7 @@ Install
 .. code-block:: bash
 
   python3 -m venv ghc && cd ghc
-  source ghc/bin/activate
+  source ./bin/activate
   git clone https://github.com/geopython/GeoHealthCheck.git
   cd GeoHealthCheck
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-astroid==2.15.8
+astroid==2.15.8 # https://github.com/sphinx-extensions2/sphinx-autodoc2/issues/31 
 Jinja2==3.0.3
 markupsafe==2.0.1
 Flask==1.1.1
@@ -10,7 +10,7 @@ SQLAlchemy==1.3.8
 Flask-SQLAlchemy==2.4.0
 itsdangerous==1.1.0
 pyproj >=2.6.1
-lxml >= 4.8.0, <= 4.9.2
+lxml >= 4.8.0, <= 4.9.4
 OWSLib==0.20.0
 jsonschema==3.0.2 # downgrade from 3.2.0 on sept 29, 2020, issue 331, consider better fix
 openapi-spec-validator==0.2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+astroid==2.15.8
 Jinja2==3.0.3
 markupsafe==2.0.1
 Flask==1.1.1


### PR DESCRIPTION
- Fix a minimal discrepancy in install instructions.
- Pin astroid to 2.15.8 to make GHC install in Ubuntu 22.4 (https://github.com/sphinx-extensions2/sphinx-autodoc2/issues/31#issuecomment-1762316427)
- Bump lxml version max to 4.9.4 to make GHC install in Ubuntu 24.4 - and probably other places using Python 3.12 (https://github.com/brightway-lca/ecoinvent_interface/issues/19#issuecomment-1824698322)