### PR TITLE
Fix typo causing bug in Run.__ge__ comparison

### DIFF
--- a/GeoHealthCheck/models.py
+++ b/GeoHealthCheck/models.py
@@ -108,7 +108,7 @@ class Run(DB.Model):
         return self.identifier > other.identifier
 
     def __ge__(self, other):
-        return self.identifief >= other.identifier
+        return self.identifier >= other.identifier
 
     def __hash__(self):
         return hash(f"{self.identifier}{self.checked_datetime}{self.resource}")


### PR DESCRIPTION
Fixed a typo in the Run class __ge__ method where `identifief` was used instead of `identifier`. 