### PR TITLE
Fix Python ImportError when loading data (itsdangerous serializer)

### DIFF
--- a/GeoHealthCheck/models.py
+++ b/GeoHealthCheck/models.py
@@ -108,7 +108,7 @@ class Run(DB.Model):
         return self.identifier > other.identifier
 
     def __ge__(self, other):
-        return self.identifief >= other.identifier
+        return self.identifier >= other.identifier
 
     def __hash__(self):
         return hash(f"{self.identifier}{self.checked_datetime}{self.resource}")

--- a/GeoHealthCheck/models.py
+++ b/GeoHealthCheck/models.py
@@ -32,7 +32,11 @@ import json
 import logging
 from flask_babel import gettext as _
 from datetime import datetime, timedelta
-from itsdangerous import TimedJSONWebSignatureSerializer as Serializer
+try:
+    from itsdangerous import TimedJSONWebSignatureSerializer as Serializer
+except ImportError:
+    from itsdangerous import URLSafeTimedSerializer as Serializer
+
 from sqlalchemy import func, and_
 
 from sqlalchemy.orm import deferred


### PR DESCRIPTION
This PR fixes an ImportError when loading data with newer versions of
itsdangerous, where TimedJSONWebSignatureSerializer is no longer available.

The code now falls back to URLSafeTimedSerializer, maintaining backward
compatibility with older itsdangerous versions.

Testing:
- Verified that running GeoHealthCheck/GeoHealthCheck/models.py no longer raises
  the TimedJSONWebSignatureSerializer ImportError.
- Further execution fails later due to missing dependencies in the local
  Windows/Python 3.13 environment, which is unrelated to this fix.

Fixes #461
